### PR TITLE
Problem: lack of inclusive gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Inclusive gateway support
+
 ### Fixed
 
 - Rhai-based condition expressions shouldn't be full scripts

--- a/bpxe/src/gateway/inclusive.rs
+++ b/bpxe/src/gateway/inclusive.rs
@@ -1,0 +1,385 @@
+//! # Inclusive Gateway
+use crate::bpmn::schema::{FlowNodeType, InclusiveGateway as Element, SequenceFlow};
+use crate::flow_node::{self, Action, FlowNode, IncomingIndex, OutgoingIndex};
+use crate::process;
+use futures::stream::Stream;
+use serde::{Deserialize, Serialize};
+use smallvec::{smallvec, SmallVec};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
+
+/// Inclusive Gateway flow node
+pub struct Gateway {
+    element: Arc<Element>,
+    state: State,
+    waker: Option<Waker>,
+    process: Option<process::Handle>,
+}
+
+impl Gateway {
+    /// Creates new Inclusive Gateway flow node
+    pub fn new(element: Element) -> Self {
+        let element = Arc::new(element);
+        Self {
+            element,
+            state: State {
+                tokens: None,
+                incoming: 0,
+                case: StateCase::Ready,
+            },
+            waker: None,
+            process: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct State {
+    tokens: Option<usize>,
+    incoming: usize,
+    case: StateCase,
+}
+
+type ProbingResult = (OutgoingIndex, bool, bool);
+
+/// Node state
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum StateCase {
+    Ready,
+    Probing,
+    AwaitingProbing {
+        probed: SmallVec<[ProbingResult; flow_node::SMALL_OUTGOING]>,
+    },
+    Done {
+        selected_outgoing: SmallVec<[OutgoingIndex; flow_node::SMALL_OUTGOING]>,
+    },
+}
+
+impl FlowNode for Gateway {
+    fn set_state(&mut self, state: flow_node::State) -> Result<(), flow_node::StateError> {
+        match state {
+            flow_node::State::InclusiveGateway(state) => {
+                self.state = state;
+                Ok(())
+            }
+            _ => Err(flow_node::StateError::InvalidVariant),
+        }
+    }
+
+    fn set_process(&mut self, process: process::Handle) {
+        self.process = Some(process);
+    }
+
+    fn get_state(&self) -> flow_node::State {
+        flow_node::State::InclusiveGateway(self.state.clone())
+    }
+
+    fn element(&self) -> Box<dyn FlowNodeType> {
+        Box::new(self.element.as_ref().clone())
+    }
+
+    fn incoming(&mut self, _index: IncomingIndex) {
+        self.state.incoming += 1;
+        if let StateCase::Ready = self.state.case {
+            self.state.case = StateCase::Probing;
+        }
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+
+    fn sequence_flow(
+        &mut self,
+        output: OutgoingIndex,
+        sequence_flow: &SequenceFlow,
+        condition_result: bool,
+    ) {
+        if let StateCase::AwaitingProbing { ref mut probed } = self.state.case {
+            probed.push((
+                output,
+                sequence_flow.id == self.element.default,
+                condition_result,
+            ));
+            // if we've probed everything
+            if probed.len() == self.element.outgoings().len() {
+                let successful: SmallVec<[ProbingResult; flow_node::SMALL_OUTGOING]> =
+                    std::mem::replace(probed, smallvec![])
+                        .into_iter()
+                        .filter(|(_, _, result)| *result)
+                        .collect();
+                // and if there were successful flows
+                if !successful.is_empty() {
+                    let successful_non_default: SmallVec<
+                        [&ProbingResult; flow_node::SMALL_OUTGOING],
+                    > = successful
+                        .iter()
+                        .filter(|(_, default, _)| !(*default as bool))
+                        .collect();
+                    // and there were some that were not default
+                    if !successful_non_default.is_empty() {
+                        // then flow
+                        self.state.case = StateCase::Done {
+                            selected_outgoing: successful_non_default
+                                .into_iter()
+                                .map(|(index, _, _)| *index)
+                                .collect(),
+                        };
+
+                        if let Some(waker) = self.waker.take() {
+                            waker.wake();
+                        }
+                        return;
+                    }
+                    // otherwise, if there was a default path
+                    let default_path =
+                        successful.iter().find_map(
+                            |(index, default, _)| {
+                                if *default {
+                                    Some(*index)
+                                } else {
+                                    None
+                                }
+                            },
+                        );
+                    if let Some(index) = default_path {
+                        // then flow
+                        self.state.case = StateCase::Done {
+                            selected_outgoing: smallvec![index],
+                        };
+
+                        if let Some(waker) = self.waker.take() {
+                            waker.wake();
+                        }
+                        return;
+                    }
+                }
+
+                // if we've probed everything and nothing worked (there's no default)
+                // ..according to the specification:
+                // "If a default path is not specified and the Process is executed such that none of the conditional Expressions
+                // evaluates to true, a runtime exception occurs"
+                let exception = process::Log::NoDefaultPath {
+                    node: Box::new(self.element.as_ref().clone()),
+                };
+                let _ = self
+                    .process
+                    .clone()
+                    .ok_or_else(|| tokio::sync::broadcast::error::SendError(exception.clone()))
+                    .and_then(|process| process.log_broadcast().send(exception));
+            }
+        }
+    }
+
+    fn tokens(&mut self, count: usize) {
+        self.state.tokens.replace(count);
+    }
+}
+
+impl From<Element> for Gateway {
+    fn from(element: Element) -> Self {
+        Self::new(element)
+    }
+}
+
+impl Stream for Gateway {
+    type Item = Action;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.state.case {
+            StateCase::Ready | StateCase::AwaitingProbing { .. } => {
+                self.waker.replace(cx.waker().clone());
+                Poll::Pending
+            }
+            StateCase::Probing => {
+                self.state.case = StateCase::AwaitingProbing {
+                    probed: smallvec![],
+                };
+                Poll::Ready(Some(Action::ProbeOutgoingSequenceFlows(
+                    (0..self.element().outgoings().len()).collect(),
+                )))
+            }
+            StateCase::Done {
+                ref selected_outgoing,
+            } => {
+                if let Some(tokens) = self.state.tokens.as_ref().take() {
+                    if *tokens >= self.state.incoming {
+                        // if enough tokens, flow
+                        let result = Poll::Ready(Some(Action::Flow(selected_outgoing.clone())));
+                        self.state.case = StateCase::Ready;
+                        return result;
+                    }
+                }
+                // if no token count, or not enough tokens, keep waiting
+                self.waker.replace(cx.waker().clone());
+                self.state.case = StateCase::Ready;
+                Poll::Pending
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bpmn::parse;
+    use crate::bpmn::schema::*;
+    use crate::event::ProcessEvent;
+    use crate::model;
+    use crate::process::Log;
+    use crate::test::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    #[cfg(any(feature = "rhai"))]
+    async fn fork() {
+        let definitions = parse(include_str!("test_models/inclusive_fork.bpmn")).unwrap();
+        let model = model::Model::new(definitions).spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+        let mut mailbox = Mailbox::new(handle.event_receiver());
+        let mut log_mailbox = Mailbox::new(handle.log_receiver());
+
+        assert!(handle.start().await.is_ok());
+
+        // End event should be reached
+        assert!(
+            log_mailbox
+                .receive(|e| if let Log::FlowNodeCompleted { node } = e {
+                    matches!(node.downcast_ref::<EndEvent>(),
+                Some(end_event) if end_event.id().as_ref().unwrap() == "end")
+                } else {
+                    false
+                })
+                .await
+        );
+
+        // f1's signal should be thrown
+        assert!(
+            mailbox
+            .receive(|e| matches!(e, ProcessEvent::SignalEvent { signal_ref } if signal_ref.as_ref().unwrap() == "f1sig"))
+            .await
+        );
+
+        // f2's signal should be thrown
+        assert!(
+            mailbox
+            .receive(|e| matches!(e, ProcessEvent::SignalEvent { signal_ref } if signal_ref.as_ref().unwrap() == "f2sig"))
+            .await
+        );
+
+        // but f3's should not
+        assert!(timeout(
+                Duration::from_millis(100),
+                mailbox.receive(
+                    |e| matches!(e, ProcessEvent::SignalEvent { signal_ref } if signal_ref.as_ref().unwrap() == "f3sig")
+                )
+        )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[cfg(any(feature = "rhai"))]
+    async fn default() {
+        let definitions = parse(include_str!("test_models/inclusive_default.bpmn")).unwrap();
+        let model = model::Model::new(definitions).spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+        let mut mailbox = Mailbox::new(handle.event_receiver());
+        let mut log_mailbox = Mailbox::new(handle.log_receiver());
+
+        assert!(handle.start().await.is_ok());
+
+        // End event should be reached
+        assert!(
+            log_mailbox
+                .receive(|e| if let Log::FlowNodeCompleted { node } = e {
+                    matches!(node.downcast_ref::<EndEvent>(),
+                Some(end_event) if end_event.id().as_ref().unwrap() == "end")
+                } else {
+                    false
+                })
+                .await
+        );
+
+        // f0's signal should be thrown
+        assert!(
+            mailbox
+            .receive(|e| matches!(e, ProcessEvent::SignalEvent { signal_ref } if signal_ref.as_ref().unwrap() == "f0sig"))
+            .await
+        );
+
+        // but f1's or f2's should not
+        assert!(timeout(
+                Duration::from_millis(100),
+                mailbox.receive(
+                    |e| matches!(e, ProcessEvent::SignalEvent { signal_ref } if signal_ref.as_ref().unwrap() == "f1sig" || signal_ref.as_ref().unwrap() == "f2sig")
+                )
+        )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[cfg(any(feature = "rhai"))]
+    async fn no_default_path() {
+        let definitions =
+            parse(include_str!("test_models/inclusive_no_default_path.bpmn")).unwrap();
+        let model = model::Model::new(definitions).spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+        let mut log_mailbox = Mailbox::new(handle.log_receiver());
+
+        assert!(handle.start().await.is_ok());
+
+        // we should see an exception
+        assert!(
+            log_mailbox
+                .receive(|e| matches!(e, Log::NoDefaultPath { .. }))
+                .await
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(any(feature = "rhai"))]
+    async fn join() {
+        let definitions = parse(include_str!("test_models/inclusive_join.bpmn")).unwrap();
+        let model = model::Model::new(definitions).spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+        let mut mailbox = Mailbox::new(handle.event_receiver());
+        let mut log_mailbox = Mailbox::new(handle.log_receiver());
+
+        assert!(handle.start().await.is_ok());
+
+        // End event should be reached
+        // Even though one condition is successful and the other is not,
+        // inclusive gateway should join on successful ones only
+        assert!(
+            log_mailbox
+                .receive(|e| if let Log::FlowNodeCompleted { node } = e {
+                    matches!(node.downcast_ref::<EndEvent>(),
+                Some(end_event) if end_event.id().as_ref().unwrap() == "end")
+                } else {
+                    false
+                })
+                .await
+        );
+        // f2's signal should be thrown
+        assert!(
+            mailbox
+            .receive(|e| matches!(e, ProcessEvent::SignalEvent { signal_ref } if signal_ref.as_ref().unwrap() == "f2sig"))
+            .await
+        );
+
+        // but f1's should not (because it was false)
+        assert!(timeout(
+                Duration::from_millis(100),
+                mailbox.receive(
+                    |e| matches!(e, ProcessEvent::SignalEvent { signal_ref } if signal_ref.as_ref().unwrap() == "f1sig")
+                )
+        )
+            .await
+            .is_err());
+    }
+}

--- a/bpxe/src/gateway/mod.rs
+++ b/bpxe/src/gateway/mod.rs
@@ -3,5 +3,7 @@ pub mod parallel;
 pub use parallel::Gateway as Parallel;
 pub mod exclusive;
 pub use exclusive::Gateway as Exclusive;
+pub mod inclusive;
+pub use inclusive::Gateway as Inclusive;
 pub mod event_based;
 pub use event_based::Gateway as EventBased;

--- a/bpxe/src/gateway/test_models/inclusive_default.bpmn
+++ b/bpxe/src/gateway/test_models/inclusive_default.bpmn
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_05pdmic" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_0i30aoo</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0i30aoo" sourceRef="start" targetRef="incl" />
+    <bpmn:inclusiveGateway id="incl" default="default">
+      <bpmn:incoming>Flow_0i30aoo</bpmn:incoming>
+      <bpmn:outgoing>Flow_07xveq8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ld9ay2</bpmn:outgoing>
+      <bpmn:outgoing>default</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_07xveq8" sourceRef="incl" targetRef="f1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="f1">
+      <bpmn:incoming>Flow_07xveq8</bpmn:incoming>
+      <bpmn:outgoing>Flow_10q33do</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_03zjbqk" signalRef="f1sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0ld9ay2" sourceRef="incl" targetRef="f2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="f2">
+      <bpmn:incoming>Flow_0ld9ay2</bpmn:incoming>
+      <bpmn:outgoing>Flow_04sifn3</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_179x1tf" signalRef="f2sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_1q1epva</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1q1epva" sourceRef="join" targetRef="end" />
+    <bpmn:sequenceFlow id="Flow_10q33do" sourceRef="f1" targetRef="join" />
+    <bpmn:sequenceFlow id="Flow_04sifn3" sourceRef="f2" targetRef="join" />
+    <bpmn:inclusiveGateway id="join">
+      <bpmn:incoming>Flow_10q33do</bpmn:incoming>
+      <bpmn:incoming>Flow_04sifn3</bpmn:incoming>
+      <bpmn:incoming>Flow_1pkzgpx</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q1epva</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:sequenceFlow id="default" sourceRef="incl" targetRef="f0" />
+    <bpmn:sequenceFlow id="Flow_1pkzgpx" sourceRef="f0" targetRef="join" />
+    <bpmn:intermediateThrowEvent id="f0">
+      <bpmn:incoming>default</bpmn:incoming>
+      <bpmn:outgoing>Flow_1pkzgpx</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1x54g62" signalRef="f0sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:textAnnotation id="TextAnnotation_1exffdq">
+      <bpmn:text>This one will be chosen as other conditions are false</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0hyxpp7" sourceRef="f0" targetRef="TextAnnotation_1exffdq" />
+  </bpmn:process>
+  <bpmn:signal id="f1sig" name="f1sig" />
+  <bpmn:signal id="f2sig" name="f2sig" />
+  <bpmn:signal id="f0sig" name="f0sig" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNShape id="TextAnnotation_1exffdq_di" bpmnElement="TextAnnotation_1exffdq">
+        <dc:Bounds x="510" y="70" width="200" height="40" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0je51qr_di" bpmnElement="default">
+        <di:waypoint x="315" y="247" />
+        <di:waypoint x="372" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04sifn3_di" bpmnElement="Flow_04sifn3">
+        <di:waypoint x="408" y="320" />
+        <di:waypoint x="500" y="320" />
+        <di:waypoint x="500" y="272" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10q33do_di" bpmnElement="Flow_10q33do">
+        <di:waypoint x="408" y="170" />
+        <di:waypoint x="500" y="170" />
+        <di:waypoint x="500" y="222" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q1epva_di" bpmnElement="Flow_1q1epva">
+        <di:waypoint x="525" y="247" />
+        <di:waypoint x="602" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ld9ay2_di" bpmnElement="Flow_0ld9ay2">
+        <di:waypoint x="290" y="272" />
+        <di:waypoint x="290" y="320" />
+        <di:waypoint x="372" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07xveq8_di" bpmnElement="Flow_07xveq8">
+        <di:waypoint x="290" y="222" />
+        <di:waypoint x="290" y="170" />
+        <di:waypoint x="372" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i30aoo_di" bpmnElement="Flow_0i30aoo">
+        <di:waypoint x="215" y="247" />
+        <di:waypoint x="265" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pkzgpx_di" bpmnElement="Flow_1pkzgpx">
+        <di:waypoint x="408" y="247" />
+        <di:waypoint x="475" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1axg12e_di" bpmnElement="incl">
+        <dc:Bounds x="265" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xfuoq4_di" bpmnElement="f1">
+        <dc:Bounds x="372" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1udzw4u_di" bpmnElement="f2">
+        <dc:Bounds x="372" y="302" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05uzb2w_di" bpmnElement="end">
+        <dc:Bounds x="602" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05ha0nq_di" bpmnElement="join">
+        <dc:Bounds x="475" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_19eyr59_di" bpmnElement="f0">
+        <dc:Bounds x="372" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0hyxpp7_di" bpmnElement="Association_0hyxpp7">
+        <di:waypoint x="403" y="235" />
+        <di:waypoint x="534" y="110" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/gateway/test_models/inclusive_fork.bpmn
+++ b/bpxe/src/gateway/test_models/inclusive_fork.bpmn
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_05pdmic" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_0i30aoo</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0i30aoo" sourceRef="start" targetRef="incl" />
+    <bpmn:inclusiveGateway id="incl">
+      <bpmn:incoming>Flow_0i30aoo</bpmn:incoming>
+      <bpmn:outgoing>Flow_07xveq8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ld9ay2</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_07xveq8" sourceRef="incl" targetRef="f1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="f1">
+      <bpmn:incoming>Flow_07xveq8</bpmn:incoming>
+      <bpmn:outgoing>Flow_12ojslf</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_03zjbqk" signalRef="f1sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0ld9ay2" sourceRef="incl" targetRef="f2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="f2">
+      <bpmn:incoming>Flow_0ld9ay2</bpmn:incoming>
+      <bpmn:outgoing>Flow_10k0zo0</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_179x1tf" signalRef="f2sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_12ojslf</bpmn:incoming>
+      <bpmn:incoming>Flow_10k0zo0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_12ojslf" sourceRef="f1" targetRef="end" />
+    <bpmn:sequenceFlow id="Flow_10k0zo0" sourceRef="f2" targetRef="end" />
+    <bpmn:textAnnotation id="TextAnnotation_0fn1jde">
+      <bpmn:text>Testing forking behaviour</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1dnfa7f" sourceRef="incl" targetRef="TextAnnotation_0fn1jde" />
+  </bpmn:process>
+  <bpmn:signal id="f1sig" name="f1sig" />
+  <bpmn:signal id="f2sig" name="f2sig" />
+  <bpmn:signal id="f0sig" name="f0sig" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNShape id="TextAnnotation_0fn1jde_di" bpmnElement="TextAnnotation_0fn1jde">
+        <dc:Bounds x="315" y="80" width="150" height="26" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10k0zo0_di" bpmnElement="Flow_10k0zo0">
+        <di:waypoint x="408" y="320" />
+        <di:waypoint x="505" y="320" />
+        <di:waypoint x="505" y="247" />
+        <di:waypoint x="602" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12ojslf_di" bpmnElement="Flow_12ojslf">
+        <di:waypoint x="408" y="170" />
+        <di:waypoint x="505" y="170" />
+        <di:waypoint x="505" y="247" />
+        <di:waypoint x="602" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ld9ay2_di" bpmnElement="Flow_0ld9ay2">
+        <di:waypoint x="290" y="272" />
+        <di:waypoint x="290" y="320" />
+        <di:waypoint x="372" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07xveq8_di" bpmnElement="Flow_07xveq8">
+        <di:waypoint x="290" y="222" />
+        <di:waypoint x="290" y="170" />
+        <di:waypoint x="372" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i30aoo_di" bpmnElement="Flow_0i30aoo">
+        <di:waypoint x="215" y="247" />
+        <di:waypoint x="265" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1axg12e_di" bpmnElement="incl">
+        <dc:Bounds x="265" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xfuoq4_di" bpmnElement="f1">
+        <dc:Bounds x="372" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1udzw4u_di" bpmnElement="f2">
+        <dc:Bounds x="372" y="302" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05uzb2w_di" bpmnElement="end">
+        <dc:Bounds x="602" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1dnfa7f_di" bpmnElement="Association_1dnfa7f">
+        <di:waypoint x="296" y="228" />
+        <di:waypoint x="331" y="106" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/gateway/test_models/inclusive_join.bpmn
+++ b/bpxe/src/gateway/test_models/inclusive_join.bpmn
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_05pdmic" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_0i30aoo</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0i30aoo" sourceRef="start" targetRef="incl" />
+    <bpmn:inclusiveGateway id="incl">
+      <bpmn:incoming>Flow_0i30aoo</bpmn:incoming>
+      <bpmn:outgoing>Flow_07xveq8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ld9ay2</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_07xveq8" sourceRef="incl" targetRef="f1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="f1">
+      <bpmn:incoming>Flow_07xveq8</bpmn:incoming>
+      <bpmn:outgoing>Flow_10q33do</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_03zjbqk" signalRef="f1sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0ld9ay2" sourceRef="incl" targetRef="f2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="f2">
+      <bpmn:incoming>Flow_0ld9ay2</bpmn:incoming>
+      <bpmn:outgoing>Flow_04sifn3</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_179x1tf" signalRef="f2sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_1q1epva</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1q1epva" sourceRef="join" targetRef="end" />
+    <bpmn:sequenceFlow id="Flow_10q33do" sourceRef="f1" targetRef="join" />
+    <bpmn:sequenceFlow id="Flow_04sifn3" sourceRef="f2" targetRef="join" />
+    <bpmn:inclusiveGateway id="join">
+      <bpmn:incoming>Flow_10q33do</bpmn:incoming>
+      <bpmn:incoming>Flow_04sifn3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q1epva</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:textAnnotation id="TextAnnotation_0fn1jde">
+      <bpmn:text>The end will be reached because the join will be performed, even though one of the branches didn't flow (because the condition is false)</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_18c8s09" sourceRef="end" targetRef="TextAnnotation_0fn1jde" />
+  </bpmn:process>
+  <bpmn:signal id="f1sig" name="f1sig" />
+  <bpmn:signal id="f2sig" name="f2sig" />
+  <bpmn:signal id="f0sig" name="f0sig" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_04sifn3_di" bpmnElement="Flow_04sifn3">
+        <di:waypoint x="408" y="320" />
+        <di:waypoint x="500" y="320" />
+        <di:waypoint x="500" y="272" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10q33do_di" bpmnElement="Flow_10q33do">
+        <di:waypoint x="408" y="170" />
+        <di:waypoint x="500" y="170" />
+        <di:waypoint x="500" y="222" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q1epva_di" bpmnElement="Flow_1q1epva">
+        <di:waypoint x="525" y="247" />
+        <di:waypoint x="602" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ld9ay2_di" bpmnElement="Flow_0ld9ay2">
+        <di:waypoint x="290" y="272" />
+        <di:waypoint x="290" y="320" />
+        <di:waypoint x="372" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07xveq8_di" bpmnElement="Flow_07xveq8">
+        <di:waypoint x="290" y="222" />
+        <di:waypoint x="290" y="170" />
+        <di:waypoint x="372" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i30aoo_di" bpmnElement="Flow_0i30aoo">
+        <di:waypoint x="215" y="247" />
+        <di:waypoint x="265" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1axg12e_di" bpmnElement="incl">
+        <dc:Bounds x="265" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xfuoq4_di" bpmnElement="f1">
+        <dc:Bounds x="372" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1udzw4u_di" bpmnElement="f2">
+        <dc:Bounds x="372" y="302" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05uzb2w_di" bpmnElement="end">
+        <dc:Bounds x="602" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05ha0nq_di" bpmnElement="join">
+        <dc:Bounds x="475" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0fn1jde_di" bpmnElement="TextAnnotation_0fn1jde">
+        <dc:Bounds x="580" y="110" width="230" height="68" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_18c8s09_di" bpmnElement="Association_18c8s09">
+        <di:waypoint x="628" y="231" />
+        <di:waypoint x="653" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/gateway/test_models/inclusive_no_default_path.bpmn
+++ b/bpxe/src/gateway/test_models/inclusive_no_default_path.bpmn
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_05pdmic" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_0i30aoo</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0i30aoo" sourceRef="start" targetRef="incl" />
+    <bpmn:inclusiveGateway id="incl">
+      <bpmn:incoming>Flow_0i30aoo</bpmn:incoming>
+      <bpmn:outgoing>Flow_07xveq8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ld9ay2</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_07xveq8" sourceRef="incl" targetRef="f1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="f1">
+      <bpmn:incoming>Flow_07xveq8</bpmn:incoming>
+      <bpmn:outgoing>Flow_12ojslf</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_03zjbqk" signalRef="f1sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0ld9ay2" sourceRef="incl" targetRef="f2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="f2">
+      <bpmn:incoming>Flow_0ld9ay2</bpmn:incoming>
+      <bpmn:outgoing>Flow_10k0zo0</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_179x1tf" signalRef="f2sig" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_12ojslf</bpmn:incoming>
+      <bpmn:incoming>Flow_10k0zo0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_12ojslf" sourceRef="f1" targetRef="end" />
+    <bpmn:sequenceFlow id="Flow_10k0zo0" sourceRef="f2" targetRef="end" />
+    <bpmn:textAnnotation id="TextAnnotation_0fn1jde">
+      <bpmn:text>Nothing will succeed. An exception will be thrown</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmn:signal id="f1sig" name="f1sig" />
+  <bpmn:signal id="f2sig" name="f2sig" />
+  <bpmn:signal id="f0sig" name="f0sig" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_10k0zo0_di" bpmnElement="Flow_10k0zo0">
+        <di:waypoint x="408" y="320" />
+        <di:waypoint x="505" y="320" />
+        <di:waypoint x="505" y="247" />
+        <di:waypoint x="602" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12ojslf_di" bpmnElement="Flow_12ojslf">
+        <di:waypoint x="408" y="170" />
+        <di:waypoint x="505" y="170" />
+        <di:waypoint x="505" y="247" />
+        <di:waypoint x="602" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ld9ay2_di" bpmnElement="Flow_0ld9ay2">
+        <di:waypoint x="290" y="272" />
+        <di:waypoint x="290" y="320" />
+        <di:waypoint x="372" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07xveq8_di" bpmnElement="Flow_07xveq8">
+        <di:waypoint x="290" y="222" />
+        <di:waypoint x="290" y="170" />
+        <di:waypoint x="372" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i30aoo_di" bpmnElement="Flow_0i30aoo">
+        <di:waypoint x="215" y="247" />
+        <di:waypoint x="265" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1axg12e_di" bpmnElement="incl">
+        <dc:Bounds x="265" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xfuoq4_di" bpmnElement="f1">
+        <dc:Bounds x="372" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1udzw4u_di" bpmnElement="f2">
+        <dc:Bounds x="372" y="302" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05uzb2w_di" bpmnElement="end">
+        <dc:Bounds x="602" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0fn1jde_di" bpmnElement="TextAnnotation_0fn1jde">
+        <dc:Bounds x="480" y="80" width="150" height="40" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
BPMN 2.0 defines "Inclusive Gateway" that allows to model alternative
but also parallel paths within a flow.

Solution: implement a basic version of an inclusive gateway

This bring changes (enhancements?) to process scheduler as it is now in
charge of computing the number of "executable" tokens arriving at flow
nodes.
