### PR TITLE
Problem: usage of intertrait crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rhai-based condition expressions shouldn't be full scripts
 - Parsing of `script` element (`bpxe-bpmn-schema` crate)
+- Dependency on platform-dependent `linkme` crate (`bpxe-bpmn-schema` crate)
 
 ## [0.1.2] - 2021-01-23
 

--- a/bpxe-bpmn-schema/Cargo.toml
+++ b/bpxe-bpmn-schema/Cargo.toml
@@ -16,10 +16,6 @@ strong-xml = "0.6.0"
 num-bigint = { version = "0.3.1", features = ["serde"] }
 # Used for schema traversals
 downcast-rs = "1.2"
-# Used for casting between traits
-intertrait = "0.2"
-# Used for intertrait
-linkme = "0.2"
 dyn-clone = "1.0.4"
 tia = "1.0.1"
 syn = "1.0.60"

--- a/bpxe-bpmn-schema/src/expr.rs
+++ b/bpxe-bpmn-schema/src/expr.rs
@@ -42,7 +42,6 @@ impl From<FormalExpression> for Expr {
     }
 }
 
-#[cast_to]
 impl DocumentElementContainer for Expr {
     fn find_by_id_mut(&mut self, id: &str) -> Option<&mut dyn DocumentElement> {
         match self {
@@ -58,7 +57,7 @@ impl DocumentElementContainer for Expr {
         }
     }
 }
-#[cast_to]
+
 impl DocumentElement for Expr {
     fn element(&self) -> Element {
         match self {

--- a/bpxe/Cargo.toml
+++ b/bpxe/Cargo.toml
@@ -19,10 +19,6 @@ sxd-document = "0.3.2"
 thiserror = "1.0"
 # Used for schema traversals
 downcast-rs = "1.2"
-# Used for casting between traits
-intertrait = "0.2"
-# Used for intertrait
-linkme = "0.2"
 dyn-clone = "1.0.4"
 tia = "1.0.0"
 tokio = { version = "1.1", features = ["full"] }

--- a/bpxe/src/event/intermediate_catch_event.rs
+++ b/bpxe/src/event/intermediate_catch_event.rs
@@ -1,5 +1,7 @@
 //! # Intermediate Catch Event flow node
-use crate::bpmn::schema::{EventDefinitionType, FlowNodeType, IntermediateCatchEvent as Element};
+use crate::bpmn::schema::{
+    Cast, EventDefinitionType, FlowNodeType, IntermediateCatchEvent as Element,
+};
 use crate::event::ProcessEvent;
 use crate::flow_node::{self, Action, FlowNode, IncomingIndex};
 use crate::process;
@@ -156,12 +158,9 @@ impl Stream for IntermediateCatchEvent {
                             let events: Vec<ProcessEvent> = event_definitions
                                 .iter()
                                 .filter_map(|event_definition| {
-                                    use intertrait::cast::CastBox;
-                                    if let Ok(definition) = event_definition
-                                        .clone()
-                                        .into_inner()
-                                        .cast::<dyn EventDefinitionType>()
-                                    {
+                                    if let Some(definition) = Cast::<dyn EventDefinitionType>::cast(
+                                        event_definition.clone().into_inner().as_ref(),
+                                    ) {
                                         use std::convert::TryFrom;
                                         if let Ok(event) = ProcessEvent::try_from(definition) {
                                             if event == e {

--- a/bpxe/src/event/intermediate_throw_event.rs
+++ b/bpxe/src/event/intermediate_throw_event.rs
@@ -1,5 +1,7 @@
 //! # Intermediate Throw Event flow node
-use crate::bpmn::schema::{EventDefinitionType, FlowNodeType, IntermediateThrowEvent as Element};
+use crate::bpmn::schema::{
+    Cast, EventDefinitionType, FlowNodeType, IntermediateThrowEvent as Element,
+};
 use crate::event::ProcessEvent;
 use crate::flow_node::{self, Action, FlowNode, IncomingIndex};
 use futures::stream::Stream;
@@ -91,12 +93,9 @@ impl Stream for IntermediateThrowEvent {
                         let _ = event_broadcaster.send(ProcessEvent::NoneEvent);
                     } else {
                         for event_definition in &self.element.event_definitions {
-                            use intertrait::cast::CastBox;
-                            if let Ok(definition) = event_definition
-                                .clone()
-                                .into_inner()
-                                .cast::<dyn EventDefinitionType>()
-                            {
+                            if let Some(definition) = Cast::<dyn EventDefinitionType>::cast(
+                                event_definition.clone().into_inner().as_ref(),
+                            ) {
                                 use std::convert::TryFrom;
                                 if let Ok(event) = ProcessEvent::try_from(definition) {
                                     let _ = event_broadcaster.send(event);

--- a/bpxe/src/event/mod.rs
+++ b/bpxe/src/event/mod.rs
@@ -142,51 +142,38 @@ impl<T> From<Box<T>> for ConversionError {
     }
 }
 
-impl TryFrom<Box<dyn EventDefinitionType>> for ProcessEvent {
+impl TryFrom<&dyn EventDefinitionType> for ProcessEvent {
     type Error = ConversionError;
-    fn try_from(mut event_definition: Box<dyn EventDefinitionType>) -> Result<Self, Self::Error> {
-        match event_definition.downcast::<CancelEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+    fn try_from(event_definition: &dyn EventDefinitionType) -> Result<Self, Self::Error> {
+        if let Some(e) = event_definition.downcast_ref::<CancelEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-        match event_definition.downcast::<TerminateEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+        if let Some(e) = event_definition.downcast_ref::<TerminateEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-        match event_definition.downcast::<CompensateEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+        if let Some(e) = event_definition.downcast_ref::<CompensateEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-        match event_definition.downcast::<MessageEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+        if let Some(e) = event_definition.downcast_ref::<MessageEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-
-        match event_definition.downcast::<EscalationEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+        if let Some(e) = event_definition.downcast_ref::<EscalationEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-
-        match event_definition.downcast::<LinkEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+        if let Some(e) = event_definition.downcast_ref::<LinkEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-        match event_definition.downcast::<ErrorEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+        if let Some(e) = event_definition.downcast_ref::<ErrorEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-        match event_definition.downcast::<ConditionalEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+        if let Some(e) = event_definition.downcast_ref::<ConditionalEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-        match event_definition.downcast::<TimerEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(e) => event_definition = e,
+        if let Some(e) = event_definition.downcast_ref::<TimerEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
-        #[allow(clippy::single_match)] // want to keep using the same pattern
-        match event_definition.downcast::<SignalEventDefinition>() {
-            Ok(e) => return ProcessEvent::try_from(*e),
-            Err(_) => {}
+        if let Some(e) = event_definition.downcast_ref::<SignalEventDefinition>() {
+            return ProcessEvent::try_from(e.clone());
         }
 
         Err(ConversionError::NotImplemented)


### PR DESCRIPTION
We're currently using [intertrait](https://crates.io/crates/intertrait), which depends on [linkme](https://crates.io/crates/linkme). While it works on Linux, macOS and Windows, it might not work elsewhere as it's platform-dependent.

In fact, there's no support for WebAssembly: https://github.com/dtolnay/linkme/issues/6 and that's one of the goals for BPXE.

Solution: roll our own `Cast` trait

It's a bit crude and is certainly less ergonomic (compared to `intertrait`) but it seems to work.

The idea is to make `DocumentElement` trait implement `Cast<T>` where `T` is all `Type` and `TypeMut` traits and then auto-generate implementations of this `Cast<T>` trait for every struct and enum.

One downside of this approach is that `autogenerated.rs` is much bigger now (approaching 7Mb). That being said, it might eventually be generated during build-time and we won't have to distribute it as is. I suppose the amount of actual code generated by trait casting crates is effectively of a similar size.

Closes #8