### PR TITLE
Problem: inability to run multiple instances of an activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inclusive gateway support
 - `scriptTask` activity support
 - `standardLoopCharacteristics` support for activities
-- `multiInstanceLoopCharacteristics` support for activities
-- Basic support for data objects
+- Limited support for data objects
+- Limited support for `multiInstanceLoopCharacteristics`
+- Limited support for `dataInputAssociation`, `dataOutputAssociation` and `ioSpecification`
 
 ### Fixed
 
 - Rhai-based condition expressions shouldn't be full scripts
 - Parsing of `script` element (`bpxe-bpmn-schema` crate)
 - Dependency on platform-dependent `linkme` crate (`bpxe-bpmn-schema` crate)
+- Improper pluralization for elements like `properties` and `.._refs` (`bxpe-bpmn-schema` crate)
+- Parsing of child elements with names different from their type (`bpxe-bpmn-schema` create)
 
 ## [0.1.2] - 2021-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inclusive gateway support
 - `scriptTask` activity support
 - `standardLoopCharacteristics` support for activities
+- `multiInstanceLoopCharacteristics` support for activities
+- Basic support for data objects
 
 ### Fixed
 

--- a/bpxe-bpmn-schema/Cargo.toml
+++ b/bpxe-bpmn-schema/Cargo.toml
@@ -20,6 +20,7 @@ dyn-clone = "1.0.4"
 tia = "1.0.1"
 syn = "1.0.60"
 serde = { version = "1.0.119", features = ["derive"] }
+derive_more = "0.99.11"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.2"

--- a/bpxe-bpmn-schema/src/lib.rs
+++ b/bpxe-bpmn-schema/src/lib.rs
@@ -98,6 +98,9 @@ pub use expr::*;
 mod script;
 pub use script::*;
 
+mod token;
+use token::*;
+
 #[derive(Error, Debug)]
 pub enum EstablishSequenceFlowError {
     #[error("source.id must be Some")]
@@ -141,7 +144,7 @@ impl Process {
             id: Some(id.to_string()),
             source_ref: source.to_string(),
             target_ref: target.to_string(),
-            condition_expression: condition_expression.map(|e| e.into()),
+            condition_expression: condition_expression.map(|e| e.into().into()),
             ..SequenceFlow::default()
         };
 
@@ -209,7 +212,8 @@ fn establishing_sequence_flow_in_process() {
 
     let expr = seq_flow.condition_expression().as_ref().unwrap();
     assert!(
-        matches!(expr, Expr::FormalExpression(FormalExpression { content, ..}) if content.as_ref().unwrap() == "condition")
+        matches!(expr, SequenceFlowConditionExpression(Expr::FormalExpression(FormalExpression { content, ..}))
+            if content.as_ref().unwrap() == "condition")
     );
 
     let start = Cast::<dyn FlowNodeType>::cast(process.find_by_id("start").unwrap()).unwrap();
@@ -280,7 +284,7 @@ where
     // it is safe now to unwrap ids
     sequence_flow.set_source_ref(source.id().as_ref().unwrap().into());
     sequence_flow.set_target_ref(target.id().as_ref().unwrap().into());
-    sequence_flow.set_condition_expression(condition_expression.map(|e| e.into()));
+    sequence_flow.set_condition_expression(condition_expression.map(|e| e.into().into()));
 
     let id = id_s.unwrap();
     source.outgoings_mut().push(id.clone());
@@ -313,7 +317,8 @@ fn establishing_sequence_flow() {
     assert_eq!(end.incomings(), &vec!["test".to_string()]);
     let expr = seq_flow.condition_expression().as_ref().unwrap();
     assert!(
-        matches!(expr, Expr::FormalExpression(FormalExpression { content, ..}) if content.as_ref().unwrap() == "condition")
+        matches!(expr, SequenceFlowConditionExpression(Expr::FormalExpression(FormalExpression { content, ..}))
+            if content.as_ref().unwrap() == "condition")
     );
 }
 

--- a/bpxe-bpmn-schema/src/token.rs
+++ b/bpxe-bpmn-schema/src/token.rs
@@ -1,0 +1,126 @@
+//! # XML token hacks
+//!
+//! ## Warning
+//!
+//! This module contains hacks and workaround for dealing with strong-xml/xmlparser and BPMN's
+//! quirks. Internal use only.
+use strong_xml::xmlparser::{ElementEnd, Token};
+use strong_xml::{XmlError, XmlReader, XmlResult};
+
+pub(crate) trait ReadSource {
+    /// Reads an element to the end and returns the source of it, renamed.
+    ///
+    /// This is done so that we can use other XmlReaders that were generated
+    /// for other tags.
+    fn read_source_till_end(&mut self, rename: &str, to: &str) -> XmlResult<String>;
+}
+
+fn push_token(token: Token, s: &mut String, rename: &str, to: &str) {
+    match token {
+        Token::Declaration { span, .. } => s.push_str(span.as_str()),
+        Token::ProcessingInstruction { span, .. } => s.push_str(span.as_str()),
+        Token::Comment { span, .. } => s.push_str(span.as_str()),
+        Token::DtdStart { span, .. } => s.push_str(span.as_str()),
+        Token::EmptyDtd { span, .. } => s.push_str(span.as_str()),
+        Token::EntityDeclaration { span, .. } => s.push_str(span.as_str()),
+        Token::DtdEnd { span, .. } => s.push_str(span.as_str()),
+        Token::ElementStart { prefix, local, .. } => {
+            s.push('<');
+            if !prefix.as_str().is_empty() {
+                s.push_str(prefix.as_str());
+                s.push(':');
+            }
+            if local.as_str() == rename {
+                s.push_str(to);
+            } else {
+                s.push_str(local.as_str());
+            }
+            s.push(' ');
+        }
+        Token::Attribute { span, .. } => {
+            s.push_str(span.as_str());
+            s.push(' ');
+        }
+        Token::ElementEnd {
+            end: ElementEnd::Close(prefix, local),
+            ..
+        } => {
+            s.push_str("</");
+            if !prefix.as_str().is_empty() {
+                s.push_str(prefix.as_str());
+                s.push(':');
+            }
+            if local.as_str() == rename {
+                s.push_str(to);
+            } else {
+                s.push_str(local.as_str());
+            }
+            s.push('>');
+        }
+        Token::ElementEnd { span, .. } => s.push_str(span.as_str()),
+        Token::Text { text, .. } => s.push_str(text.as_str()),
+        Token::Cdata { span, .. } => s.push_str(span.as_str()),
+    }
+}
+
+impl<'a> ReadSource for XmlReader<'a> {
+    fn read_source_till_end(&mut self, rename: &str, to: &str) -> XmlResult<String> {
+        let mut body = String::new();
+        let mut tag = "".to_string();
+        if let Some(start) = self.peek() {
+            match start {
+                Ok(Token::ElementStart { local, .. }) => {
+                    tag.push_str(local.as_str());
+                }
+                token => {
+                    return Err(XmlError::UnexpectedToken {
+                        token: format!("{:?}", token),
+                    });
+                }
+            }
+        }
+        let mut container = false;
+        while let Some(token) = self.next() {
+            match token? {
+                Token::ElementEnd {
+                    end: ElementEnd::Close(ns, local),
+                    span,
+                    ..
+                } if local.as_str() == tag => {
+                    push_token(
+                        Token::ElementEnd {
+                            end: ElementEnd::Close(ns, local),
+                            span,
+                        },
+                        &mut body,
+                        rename,
+                        to,
+                    );
+                    return Ok(body);
+                }
+                token
+                @
+                Token::ElementEnd {
+                    end: ElementEnd::Close(_, _),
+                    ..
+                } if !container => {
+                    container = true;
+                    push_token(token, &mut body, rename, to);
+                }
+                token
+                @
+                Token::ElementEnd {
+                    end: ElementEnd::Empty,
+                    ..
+                } if !container => {
+                    push_token(token, &mut body, rename, to);
+                    return Ok(body);
+                }
+                token => {
+                    push_token(token, &mut body, rename, to);
+                }
+            }
+        }
+        Ok(body)
+    }
+}

--- a/bpxe/Cargo.toml
+++ b/bpxe/Cargo.toml
@@ -32,6 +32,7 @@ num-bigint = { version = "0.3.1", features = ["serde"] }
 serde_json = "1.0"
 streamunordered = "0.5.1"
 derive_more = "0.99.11"
+instant = "0.1.9"
 
 [dev-dependencies]
 serde_yaml = "0.8"

--- a/bpxe/Cargo.toml
+++ b/bpxe/Cargo.toml
@@ -29,10 +29,12 @@ rhai = { version = "0.19.10", features = ["sync", "serde"], optional = true }
 async-trait = "0.1"
 factory = "0.1.2"
 num-bigint = { version = "0.3.1", features = ["serde"] }
+serde_json = "1.0"
+streamunordered = "0.5.1"
+derive_more = "0.99.11"
 
 [dev-dependencies]
 serde_yaml = "0.8"
-serde_json = "1.0"
 toml = "0.5"
 ron = "0.6"
 rmp-serde = "0.15"

--- a/bpxe/src/activity/mod.rs
+++ b/bpxe/src/activity/mod.rs
@@ -1,35 +1,40 @@
 //! Activity
 use crate::bpmn::schema::{
-    ActivityType, Expr, FlowNodeType, FormalExpression, LoopCharacteristics, SequenceFlow,
-    StandardLoopCharacteristics,
+    ActivityType, Expr, FlowNodeType, FormalExpression, LoopCharacteristics,
+    MultiInstanceLoopCharacteristics, SequenceFlow, StandardLoopCharacteristics,
 };
+use crate::data_object;
 use crate::flow_node::{self, Action, FlowNode, IncomingIndex, OutgoingIndex, StateError};
 use crate::language::{Engine as _, MultiLanguageEngine};
 use crate::process::{self, Log};
+use factory::ParameterizedFactory;
 use futures::stream::{Stream, StreamExt};
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
-use tokio::sync::{broadcast, watch};
+use streamunordered::{StreamUnordered, StreamYield};
+use tokio::sync::{broadcast, oneshot, watch};
 use tokio::task;
 
 pub mod script_task;
 
 pub trait Activity: FlowNode {
-    // Signals execution request
+    /// Signals execution request
     fn execute(&mut self);
 }
 
-pub struct ActivityContainer<T, E>
+pub struct ActivityContainer<T, E, F>
 where
     T: Activity,
     E: ActivityType + Clone + Unpin,
+    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin,
 {
     state: InnerState,
-    variant: Variant,
-    flow_nodes: Vec<T>,
+    variant: Variant<T>,
+    flow_nodes: StreamUnordered<T>,
+    flow_node_tokens: Vec<usize>,
     element: E,
     engine: Arc<MultiLanguageEngine>,
     notifier: broadcast::Sender<Completion>,
@@ -38,12 +43,20 @@ where
     waker: Option<Waker>,
     waker_sender: watch::Sender<Option<Waker>>,
     waker_receiver: watch::Receiver<Option<Waker>>,
+    flow_node_maker: F,
+    process: Option<process::Handle>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-enum Variant {
+#[derive(Debug)]
+enum Variant<T> {
+    Initializing {
+        activities: oneshot::Receiver<(IncomingIndex, Vec<T>)>,
+    },
     Initialized,
-    Ready { test_before: bool },
+    Ready {
+        // for standard loop
+        test_before: bool,
+    },
     Executing,
     Testing,
     Errored,
@@ -56,31 +69,39 @@ enum Completion {
     Error,
 }
 
-impl<T, E> ActivityContainer<T, E>
+impl<T, E, F> ActivityContainer<T, E, F>
 where
     T: Activity,
     E: ActivityType + Clone + Unpin,
+    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin,
 {
-    pub fn new<F>(element: E, flow_node_maker: F) -> Self
-    where
-        F: Fn(E) -> T,
-    {
+    pub fn new(element: E, flow_node_maker: F) -> Self {
         let (notifier, notifier_receiver) = broadcast::channel(1);
         let (waker_sender, waker_receiver) = watch::channel(None);
-        let flow_nodes = match element.loop_characteristics() {
-            None => vec![flow_node_maker(element.clone())],
+        let mut activities = match element.loop_characteristics() {
+            None => vec![flow_node_maker.create(element.clone())],
             Some(LoopCharacteristics::StandardLoopCharacteristics(_)) => {
-                vec![flow_node_maker(element.clone())]
+                vec![flow_node_maker.create(element.clone())]
             }
-            // TODO: implement `MultiInstanceLoopCharacteristics`
-            _ => vec![flow_node_maker(element.clone())],
+            Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(_)) => {
+                // Can't prepare multi-instance activities at creation
+                vec![]
+            }
         };
+
+        let mut flow_node_tokens = vec![];
+        let mut flow_nodes = StreamUnordered::new();
+        for activity in activities.drain(..) {
+            flow_node_tokens.push(flow_nodes.push(activity));
+        }
+
         Self {
             state: InnerState {
                 counter: BigInt::from(0usize),
             },
             variant: Variant::Initialized,
             flow_nodes,
+            flow_node_tokens,
             element,
             engine: Arc::new(MultiLanguageEngine::new()),
             notifier,
@@ -89,6 +110,8 @@ where
             waker: None,
             waker_sender,
             waker_receiver,
+            flow_node_maker,
+            process: None,
         }
     }
 
@@ -113,10 +136,11 @@ pub struct InnerState {
     counter: BigInt,
 }
 
-impl<T, E> FlowNode for ActivityContainer<T, E>
+impl<T, E, F> FlowNode for ActivityContainer<T, E, F>
 where
-    T: Activity,
+    T: Activity + 'static,
     E: ActivityType + Clone + Unpin,
+    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin + 'static,
 {
     fn set_state(&mut self, state: flow_node::State) -> Result<(), StateError> {
         match state {
@@ -124,8 +148,8 @@ where
                 if state.0.len() != self.flow_nodes.len() {
                     return Err(StateError::InvalidVariant);
                 }
-                for (index, inner_state) in state.0.drain(..).enumerate() {
-                    self.flow_nodes[index].set_state(inner_state)?;
+                for (inner_state, flow_node) in state.0.drain(..).zip(self.flow_nodes.iter_mut()) {
+                    flow_node.set_state(inner_state)?;
                 }
 
                 self.state = state.1;
@@ -136,9 +160,9 @@ where
         Ok(())
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::ActivityState(State(
-            self.flow_nodes.iter().map(FlowNode::get_state).collect(),
+            self.flow_nodes.iter_mut().map(|f| f.get_state()).collect(),
             self.state.clone(),
         ))
     }
@@ -149,6 +173,7 @@ where
         for flow_node in self.flow_nodes.iter_mut() {
             flow_node.set_process(process.clone());
         }
+        self.process.replace(process);
         self.wake();
     }
 
@@ -183,6 +208,88 @@ where
 
     fn incoming(&mut self, index: IncomingIndex) {
         if let Variant::Initialized = self.variant {
+            // If we need to launch a multi-instance activity, we need to populate the flow nodes
+            // upon activation
+            if self.flow_nodes.is_empty() {
+                if let Some(process) = self.process.clone() {
+                    let (sender, receiver) = oneshot::channel();
+                    let element = self.element.clone();
+                    let flow_node_maker = self.flow_node_maker.clone();
+                    let waker_receiver = self.waker_receiver.clone();
+                    task::spawn(async move {
+                        let loop_characteristics = element.loop_characteristics();
+                        let activities = match loop_characteristics {
+                            // Multi-instance loops:
+                            //  - loopCardinality given
+                            Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
+                                MultiInstanceLoopCharacteristics {
+                                    loop_cardinality: Some(Expr::FormalExpression(expr)),
+                                    ..
+                                },
+                            )) => {
+                                let engine = process.model().expression_engine_factory().create();
+                                match engine.eval::<usize>(expr).await {
+                                    Ok(cardinality) => (0..cardinality)
+                                        .into_iter()
+                                        .map(|_| flow_node_maker.create(element.clone()))
+                                        .collect(),
+                                    Err(err) => {
+                                        let _ =
+                                            process.log_broadcast().send(Log::ExpressionError {
+                                                error: format!("{:?}", err),
+                                            });
+                                        vec![]
+                                    }
+                                }
+                            }
+                            // - loopDataInput given
+                            Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
+                                MultiInstanceLoopCharacteristics {
+                                    loop_data_input_ref: Some(loop_data_input),
+                                    ..
+                                },
+                            )) => {
+                                match process.data_object(loop_data_input).await {
+                                    Ok(data_object) => {
+                                        let data_object = data_object.read().await;
+                                        if let Some(collection) =
+                                            data_object.downcast_ref::<data_object::Collection>()
+                                        {
+                                            (0..collection.len())
+                                                .into_iter()
+                                                .map(|_| flow_node_maker.create(element.clone()))
+                                                .collect()
+                                        } else {
+                                            // it is not a collection
+                                            // TODO: handle error
+                                            vec![]
+                                        }
+                                    }
+                                    Err(_) => {
+                                        // there is no such data object
+                                        // TODO: handle error
+                                        vec![]
+                                    }
+                                }
+                            }
+                            // otherwise, do nothing
+                            _ => vec![],
+                        };
+
+                        let _ = sender.send((index, activities));
+                        let waker = waker_receiver.borrow();
+                        if let Some(waker) = waker.as_ref() {
+                            waker.wake_by_ref();
+                        }
+                    });
+                    self.variant = Variant::Initializing {
+                        activities: receiver,
+                    };
+                    self.wake();
+                    return;
+                }
+            }
+
             self.variant = Variant::Ready { test_before: false };
         }
         for flow_node in self.flow_nodes.iter_mut() {
@@ -199,10 +306,11 @@ where
     }
 }
 
-impl<T, E> ActivityContainer<T, E>
+impl<T, E, F> ActivityContainer<T, E, F>
 where
     T: Activity,
     E: ActivityType + Clone + Unpin,
+    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin,
 {
     fn spawn_test(&self, expression: FormalExpression) {
         let engine = self.engine.clone();
@@ -237,13 +345,25 @@ where
     fn handle_flow_node(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Action>> {
         match self.element.loop_characteristics() {
             None => {
-                if self.variant != Variant::Executing {
-                    self.flow_nodes[0].execute();
+                let token = self.flow_node_tokens[0];
+                if !matches!(self.variant, Variant::Executing) {
+                    if let Some(flow_node) = self.flow_nodes.get_mut(token) {
+                        flow_node.execute()
+                    }
                     self.variant = Variant::Executing;
                 }
                 self.wake_when_ready(cx.waker().clone());
-                self.get_mut().flow_nodes[0].poll_next_unpin(cx)
+                self.flow_nodes.poll_next_unpin(cx).map(|item| match item {
+                    Some((StreamYield::Item(item), _)) => Some(item),
+                    Some((StreamYield::Finished(stream), _)) => {
+                        stream.remove(Pin::new(&mut self.flow_nodes));
+                        None
+                    }
+                    None => None,
+                })
             }
+            // Standard loop
+            //   - with loopCondition specified
             Some(LoopCharacteristics::StandardLoopCharacteristics(
                 StandardLoopCharacteristics {
                     test_before,
@@ -266,23 +386,32 @@ where
                 let me = self.get_mut();
                 if should_run {
                     if let Variant::Ready { .. } = me.variant {
-                        me.flow_nodes[0].execute();
+                        if let Some(flow_node) = me.flow_nodes.get_mut(me.flow_node_tokens[0]) {
+                            flow_node.execute()
+                        }
                         me.variant = Variant::Executing;
                     }
-                    let result = me.flow_nodes[0].poll_next_unpin(cx);
+                    let result = me.flow_nodes.poll_next_unpin(cx);
                     match result {
-                        Poll::Pending => {
+                        Poll::Pending | Poll::Ready(None) => {
                             me.wake_when_ready(cx.waker().clone());
                             Poll::Pending
                         }
-                        Poll::Ready(action) => {
-                            me.state.counter += 1;
-                            if !matches!(test_before, Some(true)) {
-                                me.variant = Variant::Testing;
-                                me.spawn_test(expression);
+                        Poll::Ready(Some(item)) => match item {
+                            (StreamYield::Item(action), _) => {
+                                me.state.counter += 1;
+                                if !matches!(test_before, Some(true)) {
+                                    me.variant = Variant::Testing;
+                                    me.spawn_test(expression);
+                                }
+                                Poll::Ready(Some(action))
                             }
-                            Poll::Ready(action)
-                        }
+                            (StreamYield::Finished(finished), _) => {
+                                finished.remove(Pin::new(&mut me.flow_nodes));
+                                me.wake_when_ready(cx.waker().clone());
+                                Poll::Pending
+                            }
+                        },
                     }
                 } else {
                     me.variant = Variant::Testing;
@@ -291,23 +420,160 @@ where
                     Poll::Pending
                 }
             }
-            // TODO: implement `MultiInstanceLoopCharacteristics`
-            _ => {
+            //  - with no loopCondition specified
+            Some(LoopCharacteristics::StandardLoopCharacteristics(
+                StandardLoopCharacteristics { .. },
+            )) => {
+                // From the specification:
+                // The looping behavior MAY be underspecified, meaning that the modeler can simply
+                // document the condition, in which case the loop cannot be formally executed.
                 self.wake_when_ready(cx.waker().clone());
                 Poll::Pending
             }
+            // MultiInstanceLoopCharacteristics
+            //  - no instances left
+            Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(_))
+                if self.flow_nodes.is_empty() =>
+            {
+                self.wake_when_ready(cx.waker().clone());
+                Poll::Pending
+            }
+            //  - sequential
+            Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
+                MultiInstanceLoopCharacteristics {
+                    is_sequential: Some(true),
+                    ..
+                },
+            )) => {
+                let me = self.get_mut();
+                if let Variant::Ready { .. } = me.variant {
+                    if let Some(flow_node) = me.flow_nodes.get_mut(me.flow_node_tokens[0]) {
+                        flow_node.execute()
+                    }
+                    me.variant = Variant::Executing;
+                }
+                let result = me.flow_nodes.poll_next_unpin(cx);
+                match result {
+                    Poll::Pending => {
+                        me.wake_when_ready(cx.waker().clone());
+                        Poll::Pending
+                    }
+                    Poll::Ready(None) => Poll::Ready(None),
+                    Poll::Ready(Some(item)) => match item {
+                        (StreamYield::Item(action), token) => {
+                            me.state.counter += 1;
+                            // unschedule the instance
+                            me.remove_token(token, true);
+
+                            me.variant = Variant::Ready { test_before: false };
+                            Poll::Ready(Some(action))
+                        }
+                        (StreamYield::Finished(finished), token) => {
+                            finished.remove(Pin::new(&mut me.flow_nodes));
+                            me.remove_token(token, false);
+                            me.wake_when_ready(cx.waker().clone());
+                            Poll::Pending
+                        }
+                    },
+                }
+            }
+            //  - parallel
+            Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
+                MultiInstanceLoopCharacteristics { .. },
+            )) => {
+                let me = self.get_mut();
+                if let Variant::Ready { .. } = me.variant {
+                    for flow_node in me.flow_nodes.iter_mut() {
+                        flow_node.execute()
+                    }
+
+                    me.variant = Variant::Executing;
+                }
+                let result = me.flow_nodes.poll_next_unpin(cx);
+                match result {
+                    Poll::Pending => {
+                        me.wake_when_ready(cx.waker().clone());
+                        Poll::Pending
+                    }
+                    Poll::Ready(None) => Poll::Ready(None),
+                    Poll::Ready(Some(item)) => match item {
+                        (StreamYield::Item(action), token) => {
+                            me.state.counter += 1;
+                            // unschedule the instance
+                            me.remove_token(token, true);
+
+                            if me.flow_node_tokens.is_empty() {
+                                me.variant = Variant::Ready { test_before: false };
+                            }
+                            Poll::Ready(Some(action))
+                        }
+                        (StreamYield::Finished(finished), token) => {
+                            finished.remove(Pin::new(&mut me.flow_nodes));
+                            me.remove_token(token, false);
+                            me.wake_when_ready(cx.waker().clone());
+                            Poll::Pending
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    fn remove_token(&mut self, token: usize, from_stream: bool) {
+        if from_stream {
+            let pinned = Pin::new(&mut self.flow_nodes);
+            pinned.remove(token);
+        }
+        if let Some((index, _)) = self
+            .flow_node_tokens
+            .iter()
+            .enumerate()
+            .find(|(_, token_)| **token_ == token)
+        {
+            self.flow_node_tokens.remove(index);
         }
     }
 }
 
-impl<T, E> Stream for ActivityContainer<T, E>
+impl<T, E, F> Stream for ActivityContainer<T, E, F>
 where
-    T: Activity,
+    T: Activity + 'static,
     E: ActivityType + Unpin + Clone,
+    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin + 'static,
 {
     type Item = Action;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.variant {
+            Variant::Initializing {
+                ref mut activities, ..
+            } => match activities.try_recv() {
+                Ok((index, mut activities)) => {
+                    let me = self.get_mut();
+                    for mut activity in activities.drain(..) {
+                        // Set up activity:
+                        // 1. Process
+                        if let Some(process) = me.process.clone() {
+                            activity.set_process(process);
+                        }
+                        // 2. Can't restore their state as the number of instances and their data may vary
+                        // 3. Signal an incoming (since Initializing can only get started this way)
+                        activity.incoming(index);
+                        me.flow_node_tokens.push(me.flow_nodes.push(activity));
+                    }
+                    me.variant = Variant::Initialized;
+                    me.incoming(index);
+                    me.poll_next_unpin(cx)
+                }
+                Err(oneshot::error::TryRecvError::Empty) => {
+                    self.wake_when_ready(cx.waker().clone());
+                    Poll::Pending
+                }
+                Err(_) => {
+                    // TODO: handle this error
+                    self.wake_when_ready(cx.waker().clone());
+                    Poll::Pending
+                }
+            },
             Variant::Initialized => {
                 self.wake_when_ready(cx.waker().clone());
                 Poll::Pending
@@ -357,6 +623,7 @@ where
 #[allow(unused_imports)]
 mod tests {
     use crate::bpmn::parse;
+    use crate::data_object;
     use crate::language::*;
     use crate::model;
     use crate::test::*;
@@ -515,6 +782,178 @@ mod tests {
 
         // It should stop when `should_run()` is false or maximum cap (2) has been reached
         // (and it has)
+        assert!(timeout(receiver.recv()).await.is_err());
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn multi_loop_cardinality() {
+        let definitions = parse(include_str!("test_models/multi_loop_cardinality.bpmn")).unwrap();
+        let (sender, mut receiver) = mpsc::channel(10);
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                let sender = sender.clone();
+                rhai_engine.register_fn(
+                    "notify",
+                    move || {
+                        while let Err(_) = sender.try_send(()) {}
+                    },
+                );
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+        assert!(handle.start().await.is_ok());
+
+        for _ in 0..3 {
+            // should repeat 3 times
+            assert_eq!(timeout(receiver.recv()).await.unwrap(), Some(()));
+        }
+
+        // It should stop when cardinality is exhausted
+        assert!(timeout(receiver.recv()).await.is_err());
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn multi_loop_cardinality_parallel() {
+        let definitions = parse(include_str!(
+            "test_models/multi_loop_cardinality_parallel.bpmn"
+        ))
+        .unwrap();
+        let (sender, mut receiver) = mpsc::channel(10);
+        use std::sync::Barrier;
+        let barrier = Arc::new(Barrier::new(3));
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                let sender = sender.clone();
+                let barrier = Arc::clone(&barrier);
+                rhai_engine.register_fn("notify", move || {
+                    barrier.wait();
+                    while let Err(_) = sender.try_send(()) {}
+                });
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+        assert!(handle.start().await.is_ok());
+
+        for _ in 0..3 {
+            // should repeat 3 times
+            assert_eq!(timeout(receiver.recv()).await.unwrap(), Some(()));
+        }
+
+        // It should stop when cardinality is exhausted
+        assert!(timeout(receiver.recv()).await.is_err());
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn multi_loop_data_object() {
+        let definitions = parse(include_str!("test_models/multi_loop_data_object.bpmn")).unwrap();
+        let (sender, mut receiver) = mpsc::channel(10);
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                let sender = sender.clone();
+                rhai_engine.register_fn(
+                    "notify",
+                    move || {
+                        while let Err(_) = sender.try_send(()) {}
+                    },
+                );
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+
+        {
+            let data_object = handle.data_object("data_object").await.unwrap();
+
+            let mut write = data_object.write().await;
+            *write = Box::new(data_object::Collection(vec![
+                Box::new(data_object::Empty),
+                Box::new(data_object::Empty),
+                Box::new(data_object::Empty),
+            ]));
+        }
+
+        assert!(handle.start().await.is_ok());
+
+        for _ in 0..3 {
+            // should repeat 3 times
+            assert_eq!(timeout(receiver.recv()).await.unwrap(), Some(()));
+        }
+
+        // It should stop when cardinality is exhausted
+        assert!(timeout(receiver.recv()).await.is_err());
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn multi_loop_data_object_parallel() {
+        let definitions = parse(include_str!(
+            "test_models/multi_loop_data_object_parallel.bpmn"
+        ))
+        .unwrap();
+        let (sender, mut receiver) = mpsc::channel(10);
+        use std::sync::Barrier;
+        let barrier = Arc::new(Barrier::new(3));
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                let sender = sender.clone();
+                let barrier = Arc::clone(&barrier);
+                rhai_engine.register_fn("notify", move || {
+                    barrier.wait();
+                    while let Err(_) = sender.try_send(()) {}
+                });
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+
+        {
+            let data_object = handle.data_object("data_object").await.unwrap();
+
+            let mut write = data_object.write().await;
+            *write = Box::new(data_object::Collection(vec![
+                Box::new(data_object::Empty),
+                Box::new(data_object::Empty),
+                Box::new(data_object::Empty),
+            ]));
+        }
+
+        assert!(handle.start().await.is_ok());
+
+        for _ in 0..3 {
+            // should repeat 3 times
+            assert_eq!(timeout(receiver.recv()).await.unwrap(), Some(()));
+        }
+
+        // It should stop when cardinality is exhausted
         assert!(timeout(receiver.recv()).await.is_err());
     }
 }

--- a/bpxe/src/activity/mod.rs
+++ b/bpxe/src/activity/mod.rs
@@ -1,16 +1,22 @@
 //! Activity
 use crate::bpmn::schema::{
-    ActivityType, Expr, FlowNodeType, FormalExpression, LoopCharacteristics,
-    MultiInstanceLoopCharacteristics, SequenceFlow, StandardLoopCharacteristics,
+    self, ActivityType, BaseElementType, DataAssociationType, DataInput, DataOutput,
+    DocumentElementContainer, Expr, FlowNodeType, FormalExpression, InputOutputSpecification,
+    InputOutputSpecificationType, InputSetType, LoopCharacteristics,
+    MultiInstanceLoopCharacteristics, MultiInstanceLoopCharacteristicsInputDataItem,
+    MultiInstanceLoopCharacteristicsLoopCardinality,
+    MultiInstanceLoopCharacteristicsOutputDataItem, OutputSetType, SequenceFlow,
+    StandardLoopCharacteristics, StandardLoopCharacteristicsLoopCondition,
 };
-use crate::data_object;
+use crate::data_object::{self, DataObject, DataObjectExt};
 use crate::flow_node::{self, Action, FlowNode, IncomingIndex, OutgoingIndex, StateError};
-use crate::language::{Engine as _, MultiLanguageEngine};
+use crate::language::{Engine as _, EngineContextProvider, MultiLanguageEngine};
 use crate::process::{self, Log};
 use factory::ParameterizedFactory;
 use futures::stream::{Stream, StreamExt};
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
@@ -23,7 +29,33 @@ pub mod script_task;
 pub trait Activity: FlowNode {
     /// Signals execution request
     fn execute(&mut self);
+
+    /// Reports input sets
+    ///
+    /// Default implementation does nothing
+    #[allow(unused_variables)]
+    fn input_sets(&mut self, input_sets: Vec<InputSet>) {}
+
+    /// Polls for output sets
+    ///
+    /// [`ActivityContainer`] expects this function to be non-idempotent, that is, the
+    /// implementation should not return the same output set twice. The output sets stored
+    /// in the implementation should be moved out via `Some(...)`.
+    ///
+    /// Default implementation returns `None`
+    fn take_output_sets(&mut self) -> Option<Vec<OutputSet>> {
+        None
+    }
 }
+
+type NamedDataObjects = HashMap<String, Box<dyn DataObject>>;
+type InputDataItem = Option<(Option<String>, Box<dyn DataObject>)>;
+
+/// Optionally named input set
+pub type InputSet = (Option<String>, Vec<Box<dyn DataObject>>);
+
+/// Optionally named output set
+pub type OutputSet = (Option<String>, Vec<Box<dyn DataObject>>);
 
 pub struct ActivityContainer<T, E, F>
 where
@@ -45,21 +77,46 @@ where
     waker_receiver: watch::Receiver<Option<Waker>>,
     flow_node_maker: F,
     process: Option<process::Handle>,
+    properties: HashMap<String, Box<dyn DataObject>>,
+    // Per-instance input data items:
+    // (index, input_data_item) => data_object
+    input_data_items: HashMap<(usize, Option<String>), Box<dyn DataObject>>,
 }
 
-#[derive(Debug)]
 enum Variant<T> {
+    // preparing instances
     Initializing {
-        activities: oneshot::Receiver<(IncomingIndex, Vec<T>)>,
+        // returns activity with an optional (named) input_data_item
+        activities: oneshot::Receiver<(IncomingIndex, Vec<(InputDataItem, T)>)>,
     },
+    // waiting for data to be retrieved
+    AwaitingData {
+        incoming: IncomingIndex,
+        data: oneshot::Receiver<NamedDataObjects>,
+    },
+    // waiting for an incoming flow
     Initialized,
+    // incoming flow has been registered
     Ready {
         // for standard loop
         test_before: bool,
     },
+    // activity is being executed
     Executing,
+    // awaiting output completion
+    AwaitingOutputs {
+        // action to send once outputs are completed
+        action: Option<Poll<Option<Action>>>,
+        // this signals output propagation completion
+        receiver: oneshot::Receiver<()>,
+        // variant to change to
+        next_variant: Box<Option<Variant<T>>>,
+    },
+    // loopCondition is being tested (standard loop)
     Testing,
+    // error happened
     Errored,
+    // done
     Done,
 }
 
@@ -71,9 +128,9 @@ enum Completion {
 
 impl<T, E, F> ActivityContainer<T, E, F>
 where
-    T: Activity,
+    T: Activity + 'static,
     E: ActivityType + Clone + Unpin,
-    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin,
+    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin + 'static,
 {
     pub fn new(element: E, flow_node_maker: F) -> Self {
         let (notifier, notifier_receiver) = broadcast::channel(1);
@@ -95,6 +152,20 @@ where
             flow_node_tokens.push(flow_nodes.push(activity));
         }
 
+        let properties = element
+            .properties()
+            .iter()
+            .filter(|property| property.id().is_some())
+            .map(|property| {
+                (
+                    property.id().as_ref().unwrap().clone(),
+                    Box::new(data_object::Empty) as Box<dyn DataObject>,
+                )
+            })
+            .collect();
+
+        let input_data_items = HashMap::new();
+
         Self {
             state: InnerState {
                 counter: BigInt::from(0usize),
@@ -112,6 +183,8 @@ where
             waker_receiver,
             flow_node_maker,
             process: None,
+            properties,
+            input_data_items,
         }
     }
 
@@ -124,6 +197,402 @@ where
     fn wake_when_ready(&mut self, waker: Waker) {
         let _ = self.waker_sender.send(Some(waker.clone()));
         self.waker.replace(waker);
+    }
+
+    fn prepare_instances(&mut self, index: IncomingIndex) {
+        if let Some(process) = self.process.clone() {
+            let (sender, receiver) = oneshot::channel();
+            let element = self.element.clone();
+            let flow_node_maker = self.flow_node_maker.clone();
+            let waker_receiver = self.waker_receiver.clone();
+            task::spawn(async move {
+                let loop_characteristics = element.loop_characteristics();
+                let activities = match loop_characteristics {
+                    // Multi-instance loops:
+                    //  - loopCardinality given
+                    Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
+                        MultiInstanceLoopCharacteristics {
+                            loop_cardinality:
+                                Some(MultiInstanceLoopCharacteristicsLoopCardinality(
+                                    Expr::FormalExpression(expr),
+                                )),
+                            ..
+                        },
+                    )) => {
+                        let engine = process.model().expression_engine_factory().create();
+                        match engine.eval::<usize>(expr, &mut engine.new_context()).await {
+                            Ok(cardinality) => (0..cardinality)
+                                .into_iter()
+                                .map(|_| (None, flow_node_maker.create(element.clone())))
+                                .collect(),
+                            Err(err) => {
+                                let _ = process.log_broadcast().send(Log::ExpressionError {
+                                    error: format!("{:?}", err),
+                                });
+                                vec![]
+                            }
+                        }
+                    }
+                    // - loopDataInput given
+                    Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
+                        MultiInstanceLoopCharacteristics {
+                            loop_data_input_ref: Some(loop_data_input),
+                            input_data_item,
+                            ..
+                        },
+                    )) => {
+                        let input_data_item = match input_data_item {
+                            Some(MultiInstanceLoopCharacteristicsInputDataItem(DataInput {
+                                id: Some(input_data_item),
+                                ..
+                            })) => Some(input_data_item),
+                            _ => None,
+                        };
+
+                        match process.data_object(loop_data_input).await {
+                            Ok(data_object) => {
+                                let data_object = data_object.read().await;
+                                if let Some(collection) =
+                                    data_object.downcast_ref::<data_object::Collection>()
+                                {
+                                    collection
+                                        .iter()
+                                        .map(|data_object| {
+                                            (
+                                                Some((
+                                                    input_data_item.cloned(),
+                                                    dyn_clone::clone_box(&**data_object),
+                                                )),
+                                                flow_node_maker.create(element.clone()),
+                                            )
+                                        })
+                                        .collect()
+                                } else {
+                                    // it is not a collection
+                                    // TODO: handle error
+                                    vec![]
+                                }
+                            }
+                            Err(_) => {
+                                // there is no such data object
+                                // TODO: handle error
+                                vec![]
+                            }
+                        }
+                    }
+                    // otherwise, do nothing
+                    _ => vec![],
+                };
+
+                let _ = sender.send((index, activities));
+                let waker = waker_receiver.borrow();
+                if let Some(waker) = waker.as_ref() {
+                    waker.wake_by_ref();
+                }
+            });
+            self.variant = Variant::Initializing {
+                activities: receiver,
+            };
+            self.wake();
+        }
+    }
+
+    fn request_data(&mut self, incoming: IncomingIndex) {
+        if let Some(process) = self.process.clone() {
+            let (sender, receiver) = oneshot::channel();
+            let element = self.element.clone();
+            let waker_receiver = self.waker_receiver.clone();
+            task::spawn(async move {
+                // Process data input association
+                let input_associations = element.data_input_associations();
+                let mut data = HashMap::new();
+                for association in input_associations {
+                    let sources = association.source_refs();
+                    for source in sources {
+                        // This is where the data object will be
+                        let mut data_object = None;
+                        // Check data objects
+                        if let Ok(data_object_) = process.data_object(source).await {
+                            let read = data_object_.read().await;
+                            data_object = Some(dyn_clone::clone_box(&**read));
+                        }
+                        if let Some(data_object) = data_object {
+                            data.insert(association.target_ref.to_owned(), data_object);
+                        }
+                    }
+                }
+                let waker = waker_receiver.borrow();
+                if let Some(waker) = waker.as_ref() {
+                    waker.wake_by_ref();
+                }
+                let _ = sender.send(data);
+            });
+            self.variant = Variant::AwaitingData {
+                data: receiver,
+                incoming,
+            };
+        }
+    }
+
+    fn connect_inputs(&mut self, data: &NamedDataObjects) {
+        let input_associations = self.element.data_input_associations();
+        for (index, flow_node) in self.flow_nodes.iter_mut().enumerate() {
+            let io_spec = self.element.io_specification();
+            let mut data_inputs = match io_spec {
+                None => HashMap::new(),
+                Some(InputOutputSpecification { data_inputs, .. }) => data_inputs
+                    .iter()
+                    .filter_map(|data_input| data_input.id().as_ref())
+                    .map(|id| (id, Box::new(data_object::Empty) as Box<dyn DataObject>))
+                    .collect(),
+            };
+
+            for association in input_associations {
+                let sources = association.source_refs();
+                if !sources.is_empty() {
+                    // TODO: handle transformations (and more than one source)
+                    // (for now we just assume there could be only one)
+                    let source = &sources[0];
+                    // figure out the source
+                    let mut item = None;
+                    // Check input data items
+                    if let Some(item_) = self
+                        .input_data_items
+                        .get(&(index, Some(source.to_string())))
+                    {
+                        item.replace(dyn_clone::clone_box(&*item_));
+                    }
+                    // Check properties
+                    if let Some(item_) = self.properties.get(source) {
+                        item.replace(dyn_clone::clone_box(&*item_));
+                    }
+                    // Check data objects
+                    if let Some(item_) = data.get(association.target_ref()) {
+                        item.replace(dyn_clone::clone_box(&*item_));
+                    }
+                    // TODO: process properties
+
+                    if let Some(item) = item {
+                        // figure out the destination
+                        // is it a data input?
+                        if let Some(data_object) = data_inputs.get_mut(association.target_ref()) {
+                            *data_object = *item;
+                        } else if let Some(data_object) =
+                            self.properties.get_mut(association.target_ref())
+                        {
+                            // is it a property?
+                            *data_object = *item;
+                        }
+                    }
+                }
+            }
+
+            // Collect input sets
+            let input_sets = match io_spec {
+                None => vec![],
+                Some(InputOutputSpecification { input_sets, .. }) => input_sets
+                    .iter()
+                    .map(|input_set| {
+                        (
+                            input_set.id().clone(),
+                            input_set
+                                .data_input_refses()
+                                .iter()
+                                .filter_map(|name| {
+                                    if let Some(data_input) = data_inputs.remove(name) {
+                                        return Some(data_input);
+                                    }
+                                    None
+                                })
+                                .collect(),
+                        )
+                    })
+                    .collect(),
+            };
+            flow_node.input_sets(input_sets);
+        }
+    }
+
+    fn connect_outputs(
+        &mut self,
+        cx: &mut Context<'_>,
+        token: usize,
+        action: Poll<Option<Action>>,
+        next_variant: Option<Variant<T>>,
+        remove_token: bool,
+    ) -> Poll<Option<Action>> {
+        if let Some(process) = self.process.clone() {
+            let process_definition = process.element();
+            if let Some(flow_node) = self.flow_nodes.get_mut(token) {
+                let mut async_associations = vec![];
+                if let Some(output_sets) = flow_node.take_output_sets() {
+                    let mut output_data_item: Box<dyn DataObject> = Box::new(data_object::Empty);
+                    let output_associations = self.element.data_output_associations().clone();
+                    // Process what we can in sync as we have access to &mut self
+                    for association in output_associations {
+                        let sources = association.source_refs();
+                        if !sources.is_empty() {
+                            // TODO: handle transformations (and more than one source)
+                            // (for now we just assume there could be only one)
+                            let source = &sources[0];
+                            // figure out the source
+                            let mut item = None;
+                            // is it data output?
+                            for (id, output_set) in &output_sets {
+                                // find matching output set definition
+                                if self.element.io_specification().is_some() {
+                                    if let Some(set) = self
+                                        .element
+                                        .io_specification()
+                                        .as_ref()
+                                        // it's ok to unwrap, we checked above
+                                        .unwrap()
+                                        .output_sets()
+                                        .iter()
+                                        .find(|set| &set.id == id)
+                                    {
+                                        // scan through data output refs
+                                        if let Some((_, data_object)) = set
+                                            .data_output_refses()
+                                            .iter()
+                                            .zip(output_set.iter())
+                                            .find(|(name, _)| name == &source)
+                                        {
+                                            item.replace(dyn_clone::clone_box(&*data_object));
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            // is it a property?
+                            if let Some(item_) = self.properties.get(source) {
+                                item.replace(dyn_clone::clone_box(&*item_));
+                            }
+                            if let Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
+                                MultiInstanceLoopCharacteristics {
+                                    output_data_item:
+                                        Some(MultiInstanceLoopCharacteristicsOutputDataItem(
+                                            DataOutput { id: Some(id), .. },
+                                        )),
+                                    ..
+                                },
+                            )) = self.element.loop_characteristics()
+                            {
+                                // is it an output data item?
+                                if id == source {
+                                    item.replace(dyn_clone::clone_box(&output_data_item));
+                                }
+                            }
+                            if let Some(item) = item {
+                                // figure out the destination
+                                if let Some(data_object) =
+                                    self.properties.get_mut(association.target_ref())
+                                {
+                                    // is it a property?
+                                    *data_object = *item;
+                                    continue;
+                                } else if let Some(
+                                    LoopCharacteristics::MultiInstanceLoopCharacteristics(
+                                        MultiInstanceLoopCharacteristics {
+                                            output_data_item:
+                                                Some(MultiInstanceLoopCharacteristicsOutputDataItem(
+                                                    DataOutput { id: Some(id), .. },
+                                                )),
+                                            ..
+                                        },
+                                    ),
+                                ) = self.element.loop_characteristics()
+                                {
+                                    // is it an output data item?
+                                    if id == association.target_ref() {
+                                        output_data_item = *item;
+                                        continue;
+                                    }
+                                }
+
+                                // is it a data object?
+                                if let Some(true) = process_definition
+                                    .find_by_id(association.target_ref())
+                                    .map(|e| {
+                                        e.downcast_ref::<schema::DataObject>().is_some()
+                                            || e.downcast_ref::<schema::DataObjectReference>()
+                                                .is_some()
+                                    })
+                                {
+                                    async_associations
+                                        .push((association.target_ref().to_string(), item));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // if there's anything that requires sync, spawn a task
+                if !async_associations.is_empty() {
+                    let (sender, receiver) = oneshot::channel();
+                    let is_variant_none = next_variant.is_none();
+                    let old_variant = std::mem::replace(
+                        &mut self.variant,
+                        Variant::AwaitingOutputs {
+                            action: Some(action),
+                            receiver,
+                            next_variant: Box::new(next_variant),
+                        },
+                    );
+
+                    // Save the old variant
+                    if is_variant_none {
+                        if let Variant::AwaitingOutputs {
+                            ref mut next_variant,
+                            ..
+                        } = self.variant
+                        {
+                            **next_variant = Some(old_variant);
+                        }
+                    }
+                    let waker_receiver = self.waker_receiver.clone();
+                    task::spawn(async move {
+                        {
+                            while let Some((data_object_name, new_object)) =
+                                async_associations.pop()
+                            {
+                                if let Ok(data_object) =
+                                    process.data_object(&data_object_name).await
+                                {
+                                    let mut write = data_object.write().await;
+                                    write.send(*new_object);
+                                }
+                            }
+                            let waker = waker_receiver.borrow();
+                            if let Some(waker) = waker.as_ref() {
+                                waker.wake_by_ref();
+                            }
+                            let _ = sender.send(());
+                        }
+                    });
+                    // Bail so that we don't send the next_variant
+                    self.wake_when_ready(cx.waker().clone());
+                    if remove_token {
+                        self.remove_token(token, true);
+                    }
+                    return Poll::Pending;
+                }
+            }
+            if remove_token {
+                self.remove_token(token, true);
+            }
+        }
+        // If we were not able to get a flow node or there were no output sets,
+        // or there was no need to use async for propagation,
+        // simply change to next_variant
+        if let Some(variant) = next_variant {
+            self.variant = variant;
+        }
+        // ...and simply return the given action
+        if action.is_pending() {
+            self.wake_when_ready(cx.waker().clone());
+        }
+        action
     }
 }
 
@@ -208,89 +677,17 @@ where
 
     fn incoming(&mut self, index: IncomingIndex) {
         if let Variant::Initialized = self.variant {
-            // If we need to launch a multi-instance activity, we need to populate the flow nodes
-            // upon activation
             if self.flow_nodes.is_empty() {
-                if let Some(process) = self.process.clone() {
-                    let (sender, receiver) = oneshot::channel();
-                    let element = self.element.clone();
-                    let flow_node_maker = self.flow_node_maker.clone();
-                    let waker_receiver = self.waker_receiver.clone();
-                    task::spawn(async move {
-                        let loop_characteristics = element.loop_characteristics();
-                        let activities = match loop_characteristics {
-                            // Multi-instance loops:
-                            //  - loopCardinality given
-                            Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
-                                MultiInstanceLoopCharacteristics {
-                                    loop_cardinality: Some(Expr::FormalExpression(expr)),
-                                    ..
-                                },
-                            )) => {
-                                let engine = process.model().expression_engine_factory().create();
-                                match engine.eval::<usize>(expr).await {
-                                    Ok(cardinality) => (0..cardinality)
-                                        .into_iter()
-                                        .map(|_| flow_node_maker.create(element.clone()))
-                                        .collect(),
-                                    Err(err) => {
-                                        let _ =
-                                            process.log_broadcast().send(Log::ExpressionError {
-                                                error: format!("{:?}", err),
-                                            });
-                                        vec![]
-                                    }
-                                }
-                            }
-                            // - loopDataInput given
-                            Some(LoopCharacteristics::MultiInstanceLoopCharacteristics(
-                                MultiInstanceLoopCharacteristics {
-                                    loop_data_input_ref: Some(loop_data_input),
-                                    ..
-                                },
-                            )) => {
-                                match process.data_object(loop_data_input).await {
-                                    Ok(data_object) => {
-                                        let data_object = data_object.read().await;
-                                        if let Some(collection) =
-                                            data_object.downcast_ref::<data_object::Collection>()
-                                        {
-                                            (0..collection.len())
-                                                .into_iter()
-                                                .map(|_| flow_node_maker.create(element.clone()))
-                                                .collect()
-                                        } else {
-                                            // it is not a collection
-                                            // TODO: handle error
-                                            vec![]
-                                        }
-                                    }
-                                    Err(_) => {
-                                        // there is no such data object
-                                        // TODO: handle error
-                                        vec![]
-                                    }
-                                }
-                            }
-                            // otherwise, do nothing
-                            _ => vec![],
-                        };
-
-                        let _ = sender.send((index, activities));
-                        let waker = waker_receiver.borrow();
-                        if let Some(waker) = waker.as_ref() {
-                            waker.wake_by_ref();
-                        }
-                    });
-                    self.variant = Variant::Initializing {
-                        activities: receiver,
-                    };
-                    self.wake();
-                    return;
-                }
+                // If we need to launch a multi-instance activity, we need to populate the flow nodes
+                // upon activation
+                self.prepare_instances(index);
+                return;
+            } else {
+                // Otherwise, we're ready to request data
+                self.request_data(index);
+                self.wake();
+                return;
             }
-
-            self.variant = Variant::Ready { test_before: false };
         }
         for flow_node in self.flow_nodes.iter_mut() {
             flow_node.incoming(index);
@@ -308,9 +705,9 @@ where
 
 impl<T, E, F> ActivityContainer<T, E, F>
 where
-    T: Activity,
+    T: Activity + 'static,
     E: ActivityType + Clone + Unpin,
-    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin,
+    F: ParameterizedFactory<Item = T, Parameter = E> + Send + Clone + Unpin + 'static,
 {
     fn spawn_test(&self, expression: FormalExpression) {
         let engine = self.engine.clone();
@@ -318,7 +715,7 @@ where
         let log_broadcast = self.log_broadcast.clone();
         let waker_receiver = self.waker_receiver.clone();
         task::spawn(async move {
-            let result = engine.eval(&expression).await;
+            let result = engine.eval(&expression, &mut engine.new_context()).await;
             // we're holding it until the end of the block
             // so that a new write won't start until a read lock
             // has been released
@@ -352,15 +749,22 @@ where
                     }
                     self.variant = Variant::Executing;
                 }
-                self.wake_when_ready(cx.waker().clone());
-                self.flow_nodes.poll_next_unpin(cx).map(|item| match item {
-                    Some((StreamYield::Item(item), _)) => Some(item),
-                    Some((StreamYield::Finished(stream), _)) => {
-                        stream.remove(Pin::new(&mut self.flow_nodes));
-                        None
+                match self.flow_nodes.poll_next_unpin(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(None) => Poll::Ready(None),
+                    Poll::Ready(Some((StreamYield::Item(item), token))) => {
+                        if let Action::Complete = item {
+                            self.variant = Variant::Done;
+                            Poll::Pending
+                        } else {
+                            self.connect_outputs(cx, token, Poll::Ready(Some(item)), None, false)
+                        }
                     }
-                    None => None,
-                })
+                    Poll::Ready(Some((StreamYield::Finished(stream), _))) => {
+                        stream.remove(Pin::new(&mut self.flow_nodes));
+                        Poll::Ready(None)
+                    }
+                }
             }
             // Standard loop
             //   - with loopCondition specified
@@ -368,7 +772,10 @@ where
                 StandardLoopCharacteristics {
                     test_before,
                     loop_maximum,
-                    loop_condition: Some(Expr::FormalExpression(expression)),
+                    loop_condition:
+                        Some(StandardLoopCharacteristicsLoopCondition(Expr::FormalExpression(
+                            expression,
+                        ))),
                     ..
                 },
             )) => {
@@ -398,13 +805,23 @@ where
                             Poll::Pending
                         }
                         Poll::Ready(Some(item)) => match item {
-                            (StreamYield::Item(action), _) => {
+                            (StreamYield::Item(action), token) => {
+                                let should_test = !matches!(test_before, Some(true));
                                 me.state.counter += 1;
-                                if !matches!(test_before, Some(true)) {
-                                    me.variant = Variant::Testing;
+                                if should_test {
                                     me.spawn_test(expression);
                                 }
-                                Poll::Ready(Some(action))
+                                me.connect_outputs(
+                                    cx,
+                                    token,
+                                    Poll::Ready(Some(action)),
+                                    if should_test {
+                                        Some(Variant::Testing)
+                                    } else {
+                                        None
+                                    },
+                                    false,
+                                )
                             }
                             (StreamYield::Finished(finished), _) => {
                                 finished.remove(Pin::new(&mut me.flow_nodes));
@@ -462,17 +879,23 @@ where
                     Poll::Ready(Some(item)) => match item {
                         (StreamYield::Item(action), token) => {
                             me.state.counter += 1;
-                            // unschedule the instance
-                            me.remove_token(token, true);
-
-                            me.variant = Variant::Ready { test_before: false };
-                            Poll::Ready(Some(action))
+                            me.connect_outputs(
+                                cx,
+                                token,
+                                Poll::Ready(Some(action)),
+                                if me.flow_nodes.len() == 1 {
+                                    Some(Variant::Done)
+                                } else {
+                                    Some(Variant::Ready { test_before: false })
+                                },
+                                true,
+                            )
                         }
                         (StreamYield::Finished(finished), token) => {
                             finished.remove(Pin::new(&mut me.flow_nodes));
+                            me.variant = Variant::Initialized;
                             me.remove_token(token, false);
-                            me.wake_when_ready(cx.waker().clone());
-                            Poll::Pending
+                            Poll::Ready(Some(Action::Complete))
                         }
                     },
                 }
@@ -499,19 +922,23 @@ where
                     Poll::Ready(Some(item)) => match item {
                         (StreamYield::Item(action), token) => {
                             me.state.counter += 1;
-                            // unschedule the instance
-                            me.remove_token(token, true);
-
-                            if me.flow_node_tokens.is_empty() {
-                                me.variant = Variant::Ready { test_before: false };
-                            }
-                            Poll::Ready(Some(action))
+                            me.connect_outputs(
+                                cx,
+                                token,
+                                Poll::Ready(Some(action)),
+                                if me.flow_nodes.len() == 1 {
+                                    Some(Variant::Done)
+                                } else {
+                                    None
+                                },
+                                true,
+                            )
                         }
                         (StreamYield::Finished(finished), token) => {
                             finished.remove(Pin::new(&mut me.flow_nodes));
+                            me.variant = Variant::Initialized;
                             me.remove_token(token, false);
-                            me.wake_when_ready(cx.waker().clone());
-                            Poll::Pending
+                            Poll::Ready(Some(Action::Complete))
                         }
                     },
                 }
@@ -549,20 +976,30 @@ where
             } => match activities.try_recv() {
                 Ok((index, mut activities)) => {
                     let me = self.get_mut();
-                    for mut activity in activities.drain(..) {
+                    for (index, (data_object, mut activity)) in activities.drain(..).enumerate() {
                         // Set up activity:
                         // 1. Process
                         if let Some(process) = me.process.clone() {
                             activity.set_process(process);
                         }
-                        // 2. Can't restore their state as the number of instances and their data may vary
-                        // 3. Signal an incoming (since Initializing can only get started this way)
-                        activity.incoming(index);
+
+                        // 2. Save input data
+                        if let Some((id, data_object)) = data_object {
+                            me.input_data_items.insert((index, id), data_object);
+                        }
+
+                        // 3. TODO: figure out deterministic state recovery
+                        // activity.set_state(...);
+
                         me.flow_node_tokens.push(me.flow_nodes.push(activity));
                     }
-                    me.variant = Variant::Initialized;
-                    me.incoming(index);
-                    me.poll_next_unpin(cx)
+                    // StreamUnordered is managing streams in a linked list and inserts at head,
+                    // therefore if we want to preserve the order of execution, we have to reverse
+                    // the tokens.
+                    me.flow_node_tokens.reverse();
+                    me.wake_when_ready(cx.waker().clone());
+                    me.request_data(index);
+                    Poll::Pending
                 }
                 Err(oneshot::error::TryRecvError::Empty) => {
                     self.wake_when_ready(cx.waker().clone());
@@ -574,6 +1011,56 @@ where
                     Poll::Pending
                 }
             },
+            Variant::AwaitingData {
+                ref mut data,
+                incoming,
+            } => {
+                match data.try_recv() {
+                    Ok(ref data) => {
+                        self.connect_inputs(data);
+                        self.variant = Variant::Ready { test_before: false };
+                        self.incoming(incoming);
+                        self.poll_next(cx)
+                    }
+                    Err(oneshot::error::TryRecvError::Empty) => {
+                        self.wake_when_ready(cx.waker().clone());
+                        Poll::Pending
+                    }
+                    Err(_) => {
+                        // TODO: handle this error
+                        self.wake_when_ready(cx.waker().clone());
+                        Poll::Pending
+                    }
+                }
+            }
+            Variant::AwaitingOutputs {
+                ref mut receiver,
+                ref mut next_variant,
+                ref mut action,
+            } => {
+                match receiver.try_recv() {
+                    Ok(()) => {
+                        // it's ok to unwrap here because connect_outputs ensures there isn't going
+                        // to be a None
+                        let result = action.take().unwrap();
+                        // ...as well as here
+                        self.variant = next_variant.take().unwrap();
+                        if result.is_pending() {
+                            self.wake_when_ready(cx.waker().clone());
+                        }
+                        result
+                    }
+                    Err(oneshot::error::TryRecvError::Empty) => {
+                        self.wake_when_ready(cx.waker().clone());
+                        Poll::Pending
+                    }
+                    Err(_) => {
+                        // TODO: handle this error
+                        self.wake_when_ready(cx.waker().clone());
+                        Poll::Pending
+                    }
+                }
+            }
             Variant::Initialized => {
                 self.wake_when_ready(cx.waker().clone());
                 Poll::Pending
@@ -612,8 +1099,7 @@ where
             }
             Variant::Done => {
                 self.variant = Variant::Ready { test_before: false };
-                self.wake_when_ready(cx.waker().clone());
-                Poll::Pending
+                Poll::Ready(Some(Action::Complete))
             }
         }
     }
@@ -622,10 +1108,11 @@ where
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    use crate::bpmn::parse;
+    use crate::bpmn::{parse, schema::*};
     use crate::data_object;
     use crate::language::*;
     use crate::model;
+    use crate::process::Log;
     use crate::test::*;
     use std::sync::Arc;
     use std::sync::Mutex;
@@ -955,5 +1442,251 @@ mod tests {
 
         // It should stop when cardinality is exhausted
         assert!(timeout(receiver.recv()).await.is_err());
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn multi_loop_data_object_input() {
+        let definitions = parse(include_str!(
+            "test_models/multi_loop_data_object_input.bpmn"
+        ))
+        .unwrap();
+        let (sender, mut receiver) = mpsc::channel(10);
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                let sender = sender.clone();
+                rhai_engine.register_fn(
+                    "notify",
+                    move |i: u8| while let Err(_) = sender.try_send(i) {},
+                );
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+
+        {
+            let data_object = handle.data_object("data_object").await.unwrap();
+
+            let mut write = data_object.write().await;
+            *write = Box::new(data_object::Collection(vec![
+                Box::new(data_object::Container(1u8)),
+                Box::new(data_object::Container(2u8)),
+                Box::new(data_object::Container(3u8)),
+            ]));
+        }
+
+        assert!(handle.start().await.is_ok());
+
+        // Should receive the data inputs
+        assert_eq!(timeout(receiver.recv()).await.unwrap(), Some(1));
+        assert_eq!(timeout(receiver.recv()).await.unwrap(), Some(2));
+        assert_eq!(timeout(receiver.recv()).await.unwrap(), Some(3));
+
+        // It should stop when cardinality is exhausted
+        assert!(timeout(receiver.recv()).await.is_err());
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn multi_loop_data_object_output() {
+        let definitions = parse(include_str!(
+            "test_models/multi_loop_data_object_output.bpmn"
+        ))
+        .unwrap();
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                rhai_engine.register_fn("notify", move |_: u8| {});
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+
+        let mut log_mailbox = Mailbox::new(handle.log_receiver());
+
+        {
+            let data_object = handle.data_object("data_object").await.unwrap();
+
+            let mut write = data_object.write().await;
+            *write = Box::new(data_object::Collection(vec![
+                Box::new(data_object::Container(1u8)),
+                Box::new(data_object::Container(2u8)),
+                Box::new(data_object::Container(3u8)),
+            ]));
+        }
+
+        assert!(handle.start().await.is_ok());
+
+        assert!(timeout(
+            log_mailbox.receive(|m| matches!(m, Log::FlowNodeCompleted { node, ..}
+                if matches!(node.downcast_ref::<ScriptTask>(), Some(ScriptTask { id, .. }) if id.as_ref().unwrap() == "script")))
+        )
+        .await
+        .is_ok());
+
+        let collection =
+            match dyn_clone::clone_box(&*handle.data_object("output").await.unwrap().read().await)
+                .downcast::<data_object::Collection>()
+            {
+                Ok(coll) => coll,
+                _ => panic!("should be a collection"),
+            };
+
+        assert_eq!(collection.len(), 3);
+        assert!(matches!(
+            collection[0].downcast_ref::<data_object::Container<i64>>(),
+            Some(data_object::Container(1))
+        ));
+        assert!(matches!(
+            collection[1].downcast_ref::<data_object::Container<i64>>(),
+            Some(data_object::Container(2))
+        ));
+        assert!(matches!(
+            collection[2].downcast_ref::<data_object::Container<i64>>(),
+            Some(data_object::Container(3))
+        ));
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn input_data_object() {
+        let definitions = parse(include_str!("test_models/activity_io.bpmn")).unwrap();
+        let (sender, mut receiver) = mpsc::channel(10);
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                let sender = sender.clone();
+                rhai_engine.register_fn("notify", move |i: ::rhai::Array| {
+                    while let Err(_) = sender.try_send(i[0].clone()) {}
+                });
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+
+        {
+            let data_object = handle.data_object("data_object").await.unwrap();
+
+            let mut write = data_object.write().await;
+            *write = Box::new(data_object::Container(1u8));
+        }
+
+        assert!(handle.start().await.is_ok());
+
+        // Should receive the data inputs
+        assert_eq!(
+            timeout(receiver.recv())
+                .await
+                .unwrap()
+                .unwrap()
+                .cast::<u8>(),
+            1
+        );
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn input_property() {
+        let definitions = parse(include_str!("test_models/activity_io.bpmn")).unwrap();
+        let (sender, mut receiver) = mpsc::channel(10);
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                let sender = sender.clone();
+                rhai_engine.register_fn("notify", move |i: ::rhai::Array| {
+                    while let Err(_) = sender.try_send(i[1].clone()) {}
+                });
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+
+        {
+            let data_object = handle.data_object("data_object").await.unwrap();
+
+            let mut write = data_object.write().await;
+            *write = Box::new(data_object::Container(1u8));
+        }
+
+        assert!(handle.start().await.is_ok());
+
+        // Should receive the data inputs
+        assert_eq!(
+            timeout(receiver.recv())
+                .await
+                .unwrap()
+                .unwrap()
+                .cast::<u8>(),
+            1
+        );
+    }
+
+    #[cfg(feature = "rhai")]
+    #[tokio::test]
+    async fn output_data_object() {
+        let definitions = parse(include_str!("test_models/activity_io.bpmn")).unwrap();
+        let model = model::Model::new(definitions).with_script_engine_factory(
+            model::FnLanguageEngineFactory(move || {
+                use ::rhai::RegisterFn;
+                let mut engine = MultiLanguageEngine::new();
+                let rhai_engine = engine.rhai.engine_mut().unwrap();
+                rhai_engine.register_fn("notify", move |_: ::rhai::Array| {});
+                engine
+            }),
+        );
+
+        let model = model.spawn().await;
+
+        let handle = model.processes().await.unwrap().pop().unwrap();
+
+        {
+            let data_object = handle.data_object("data_object").await.unwrap();
+
+            let mut write = data_object.write().await;
+            *write = Box::new(data_object::Container(1u8));
+        }
+
+        let mut log_mailbox = Mailbox::new(handle.log_receiver());
+
+        assert!(handle.start().await.is_ok());
+
+        assert!(timeout(
+            log_mailbox.receive(|m| matches!(m, Log::FlowNodeCompleted { node, ..}
+                if matches!(node.downcast_ref::<ScriptTask>(), Some(ScriptTask { id, .. }) if id.as_ref().unwrap() == "activity")))
+        )
+        .await
+        .is_ok());
+
+        assert!(matches!(
+            handle
+                .data_object("output")
+                .await
+                .unwrap()
+                .read()
+                .await
+                .downcast_ref::<data_object::Container<i64>>(),
+            Some(data_object::Container(1))
+        ));
     }
 }

--- a/bpxe/src/activity/script_task.rs
+++ b/bpxe/src/activity/script_task.rs
@@ -74,7 +74,7 @@ impl FlowNode for Task {
         }
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::ScriptTask(self.state.clone())
     }
 

--- a/bpxe/src/activity/script_task.rs
+++ b/bpxe/src/activity/script_task.rs
@@ -1,9 +1,12 @@
 //! # Script Task flow node
-use crate::activity::Activity;
+use crate::activity::{Activity, InputSet, OutputSet};
 use crate::bpmn::schema::{FlowNodeType, ScriptTask as Element};
 
+use crate::data_object::{self, DataObject};
 use crate::flow_node::{self, Action, FlowNode};
-use crate::language::{Engine as _, MultiLanguageEngine};
+use crate::language::{
+    Engine as _, EngineContext, EngineContextProvider, EvaluationError, MultiLanguageEngine,
+};
 use crate::process::Log;
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
@@ -22,11 +25,13 @@ pub struct Task {
     notifier: broadcast::Sender<Completion>,
     notifier_receiver: broadcast::Receiver<Completion>,
     log_broadcast: Option<broadcast::Sender<Log>>,
+    input_sets: Vec<InputSet>,
+    output_sets: Option<Vec<OutputSet>>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 enum Completion {
-    Success,
+    Success(Option<Vec<OutputSet>>),
     Error,
 }
 
@@ -42,6 +47,8 @@ impl Task {
             notifier,
             notifier_receiver,
             log_broadcast: None,
+            input_sets: vec![],
+            output_sets: None,
         }
     }
 
@@ -97,6 +104,14 @@ impl Activity for Task {
         self.state = State::Execute;
         self.wake();
     }
+
+    fn input_sets(&mut self, input_sets: Vec<InputSet>) {
+        self.input_sets = input_sets;
+    }
+
+    fn take_output_sets(&mut self) -> Option<Vec<OutputSet>> {
+        self.output_sets.take()
+    }
 }
 
 impl From<Element> for Task {
@@ -124,10 +139,29 @@ impl Stream for Task {
                 let element = self.element.as_ref().clone();
                 let notifier = self.notifier.clone();
                 let log_broadcast = self.log_broadcast.clone();
+                let mut context = engine.new_context();
+                // We only need input once, we can drain it
+                for (name, input_set) in
+                    std::mem::replace(&mut self.input_sets, Vec::new()).drain(..)
+                {
+                    if let Some(name) = name {
+                        context.set(&name, Box::new(data_object::Collection(input_set)));
+                    } else {
+                        context.set("input", Box::new(data_object::Collection(input_set)));
+                    }
+                }
+
                 task::spawn(async move {
-                    match engine.eval(&element).await {
-                        Ok(()) => {
-                            let _ = notifier.send(Completion::Success);
+                    match engine
+                        .eval::<Vec<Box<dyn DataObject>>>(&element, &mut context)
+                        .await
+                    {
+                        Ok(data_objects) => {
+                            let _ = notifier
+                                .send(Completion::Success(Some(vec![(None, data_objects)])));
+                        }
+                        Err(EvaluationError::ResultTypeError { got, .. }) if got == "()" => {
+                            let _ = notifier.send(Completion::Success(None));
                         }
                         Err(err) => {
                             let _ = notifier.send(Completion::Error);
@@ -143,7 +177,8 @@ impl Stream for Task {
                 Poll::Pending
             }
             State::Executing => match self.notifier_receiver.try_recv() {
-                Ok(Completion::Success) => {
+                Ok(Completion::Success(data_objects)) => {
+                    self.output_sets = data_objects;
                     self.waker.replace(cx.waker().clone());
                     self.state = State::Done;
                     Poll::Ready(Some(Action::Flow(
@@ -170,8 +205,7 @@ impl Stream for Task {
             }
             State::Done => {
                 self.state = State::Ready;
-                self.waker.replace(cx.waker().clone());
-                Poll::Pending
+                Poll::Ready(Some(Action::Complete))
             }
         }
     }

--- a/bpxe/src/activity/test_models/activity_io.bpmn
+++ b/bpxe/src/activity/test_models/activity_io.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1ohnh3g" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_1cta1at</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1cta1at" sourceRef="start" targetRef="activity" />
+    <bpmn:scriptTask id="activity">
+      <bpmn:incoming>Flow_1cta1at</bpmn:incoming>
+      <bpmn:ioSpecification>
+        <bpmn:dataInput id="instance_data" />
+        <bpmn:dataInput id="instance_data1" />
+        <bpmn:dataOutput id="out" />
+        <bpmn:inputSet>
+          <bpmn:dataInputRefs>instance_data</bpmn:dataInputRefs>
+          <bpmn:dataInputRefs>instance_data1</bpmn:dataInputRefs>
+        </bpmn:inputSet>
+        <bpmn:outputSet>
+          <bpmn:dataOutputRefs>out</bpmn:dataOutputRefs>
+        </bpmn:outputSet>
+      </bpmn:ioSpecification>
+      <bpmn:property id="prop1" name="prop1" />
+      <bpmn:dataInputAssociation id="DataInputAssociation_0hdpw3j">
+        <bpmn:sourceRef>data_object</bpmn:sourceRef>
+        <bpmn:targetRef>prop1</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+      <bpmn:dataInputAssociation id="DataInputAssociation_0hdpw3j_1">
+        <bpmn:sourceRef>data_object</bpmn:sourceRef>
+        <bpmn:targetRef>instance_data</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+      <bpmn:dataInputAssociation id="DataInputAssociation_0hdpw3j_2">
+        <bpmn:sourceRef>prop1</bpmn:sourceRef>
+        <bpmn:targetRef>instance_data1</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+      <bpmn:dataOutputAssociation id="DataOutputAssociation_0yw6l20">
+        <bpmn:sourceRef>out</bpmn:sourceRef>
+        <bpmn:targetRef>output</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+      <bpmn:script>notify(input.unveil());
+output([1.data_object()])</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:dataObjectReference id="data_object" name="Data" dataObjectRef="DataObject_03con8p" />
+    <bpmn:dataObject id="DataObject_03con8p" />
+    <bpmn:dataObjectReference id="output" dataObjectRef="DataObject_1245y00" />
+    <bpmn:dataObject id="DataObject_1245y00" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_1cta1at_di" bpmnElement="Flow_1cta1at">
+        <di:waypoint x="215" y="237" />
+        <di:waypoint x="270" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="219" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nk9lsb_di" bpmnElement="activity">
+        <dc:Bounds x="270" y="197" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_1v57oss_di" bpmnElement="data_object">
+        <dc:Bounds x="302" y="335" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="309" y="392" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_164pksy_di" bpmnElement="output">
+        <dc:Bounds x="302" y="85" width="36" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="DataInputAssociation_0hdpw3j_di" bpmnElement="DataInputAssociation_0hdpw3j">
+        <di:waypoint x="320" y="335" />
+        <di:waypoint x="320" y="277" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="DataOutputAssociation_0yw6l20_di" bpmnElement="DataOutputAssociation_0yw6l20">
+        <di:waypoint x="319" y="197" />
+        <di:waypoint x="318" y="135" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/activity/test_models/multi_loop.bpmn
+++ b/bpxe/src/activity/test_models/multi_loop.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0tg7ycw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_05bo8vg</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_05bo8vg" sourceRef="start" targetRef="Activity_0s9quw2" />
+    <bpmn:scriptTask id="Activity_0s9quw2">
+      <bpmn:incoming>Flow_05bo8vg</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics />
+      <bpmn:script>notify();</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:dataObjectReference id="data_object" dataObjectRef="DataObject_1lt20vp" />
+    <bpmn:dataObject id="DataObject_1lt20vp" isCollection="true" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_05bo8vg_di" bpmnElement="Flow_05bo8vg">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="270" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y9uqu8_di" bpmnElement="Activity_0s9quw2">
+        <dc:Bounds x="270" y="57" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_0uo00xf_di" bpmnElement="data_object">
+        <dc:Bounds x="302" y="225" width="36" height="50" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/activity/test_models/multi_loop_cardinality.bpmn
+++ b/bpxe/src/activity/test_models/multi_loop_cardinality.bpmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0cb48xz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_0bji7w1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0bji7w1" sourceRef="start" targetRef="script" />
+    <bpmn:scriptTask id="script">
+      <bpmn:incoming>Flow_0bji7w1</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">3</bpmn:loopCardinality>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:script>notify();</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_0bji7w1_di" bpmnElement="Flow_0bji7w1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nyobh8_di" bpmnElement="script">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/activity/test_models/multi_loop_cardinality_parallel.bpmn
+++ b/bpxe/src/activity/test_models/multi_loop_cardinality_parallel.bpmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0cb48xz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_0bji7w1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0bji7w1" sourceRef="start" targetRef="script" />
+    <bpmn:scriptTask id="script">
+      <bpmn:incoming>Flow_0bji7w1</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">3</bpmn:loopCardinality>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:script>notify();</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_0bji7w1_di" bpmnElement="Flow_0bji7w1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="273" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nyobh8_di" bpmnElement="script">
+        <dc:Bounds x="273" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/activity/test_models/multi_loop_data_object.bpmn
+++ b/bpxe/src/activity/test_models/multi_loop_data_object.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0tg7ycw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_05bo8vg</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_05bo8vg" sourceRef="start" targetRef="Activity_0s9quw2" />
+    <bpmn:scriptTask id="Activity_0s9quw2">
+      <bpmn:incoming>Flow_05bo8vg</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:loopDataInputRef>data_object</bpmn:loopDataInputRef>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:script>notify();</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:dataObjectReference id="data_object" name="&#10;" dataObjectRef="DataObject_1lt20vp" />
+    <bpmn:dataObject id="DataObject_1lt20vp" isCollection="true" />
+    <bpmn:textAnnotation id="TextAnnotation_09cmk6f">
+      <bpmn:text>The collection in this data object will drive the instances</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1gon8rm" sourceRef="data_object" targetRef="TextAnnotation_09cmk6f" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_05bo8vg_di" bpmnElement="Flow_05bo8vg">
+        <di:waypoint x="215" y="357" />
+        <di:waypoint x="270" y="357" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="339" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y9uqu8_di" bpmnElement="Activity_0s9quw2">
+        <dc:Bounds x="270" y="317" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_0uo00xf_di" bpmnElement="data_object">
+        <dc:Bounds x="302" y="165" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="311" y="222" width="20" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_09cmk6f_di" bpmnElement="TextAnnotation_09cmk6f">
+        <dc:Bounds x="340" y="80" width="210" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1gon8rm_di" bpmnElement="Association_1gon8rm">
+        <di:waypoint x="338" y="166" />
+        <di:waypoint x="364" y="130" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/activity/test_models/multi_loop_data_object_input.bpmn
+++ b/bpxe/src/activity/test_models/multi_loop_data_object_input.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0uhpiqz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_04leo32</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_04leo32" sourceRef="start" targetRef="script" />
+    <bpmn:scriptTask id="script">
+      <bpmn:incoming>Flow_04leo32</bpmn:incoming>
+      <bpmn:ioSpecification>
+        <bpmn:dataInput id="instance_data" />
+        <bpmn:inputSet>
+          <bpmn:dataInputRefs>instance_data</bpmn:dataInputRefs>
+        </bpmn:inputSet>
+      </bpmn:ioSpecification>
+      <bpmn:dataInputAssociation>
+        <bpmn:sourceRef>loop_input</bpmn:sourceRef>
+        <bpmn:targetRef>instance_data</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:loopDataInputRef>data_object</bpmn:loopDataInputRef>
+        <bpmn:inputDataItem id="loop_input" />
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:script>notify(input.unveil()[0]);</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:dataObjectReference id="data_object" dataObjectRef="DataObject_08crhde" />
+    <bpmn:dataObject id="DataObject_08crhde" isCollection="true" />
+    <bpmn:textAnnotation id="TextAnnotation_1gxn1t1">
+      <bpmn:text>Testing passing loop input data</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_07pnk92" sourceRef="data_object" targetRef="TextAnnotation_1gxn1t1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_04leo32_di" bpmnElement="Flow_04leo32">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="270" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_131r2hz_di" bpmnElement="script">
+        <dc:Bounds x="270" y="57" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_0f414bj_di" bpmnElement="data_object">
+        <dc:Bounds x="302" y="265" width="36" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1gxn1t1_di" bpmnElement="TextAnnotation_1gxn1t1">
+        <dc:Bounds x="410" y="250" width="100" height="40" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_07pnk92_di" bpmnElement="Association_07pnk92">
+        <di:waypoint x="338" y="287" />
+        <di:waypoint x="410" y="274" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/activity/test_models/multi_loop_data_object_output.bpmn
+++ b/bpxe/src/activity/test_models/multi_loop_data_object_output.bpmn
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0uhpiqz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_04leo32</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_04leo32" sourceRef="start" targetRef="script" />
+    <bpmn:scriptTask id="script">
+      <bpmn:incoming>Flow_04leo32</bpmn:incoming>
+      <bpmn:ioSpecification>
+        <bpmn:dataInput id="instance_data" />
+        <bpmn:dataOutput id="out" />
+        <bpmn:inputSet>
+          <bpmn:dataInputRefs>instance_data</bpmn:dataInputRefs>
+        </bpmn:inputSet>
+        <bpmn:outputSet>
+          <bpmn:dataOutputRefs>out</bpmn:dataOutputRefs>
+        </bpmn:outputSet>
+      </bpmn:ioSpecification>
+      <bpmn:dataInputAssociation>
+        <bpmn:sourceRef>loop_input</bpmn:sourceRef>
+        <bpmn:targetRef>instance_data</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+      <bpmn:dataOutputAssociation>
+        <bpmn:sourceRef>out</bpmn:sourceRef>
+        <bpmn:targetRef>loop_output</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+      <bpmn:dataOutputAssociation>
+        <bpmn:sourceRef>loop_output</bpmn:sourceRef>
+        <bpmn:targetRef>output</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:loopDataInputRef>data_object</bpmn:loopDataInputRef>
+        <bpmn:inputDataItem id="loop_input" />
+        <bpmn:outputDataItem id="loop_output" />
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:script>notify(input.unveil()[0]);
+output([input.unveil()[0].to_int().data_object()])</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:dataObjectReference id="data_object" name="Input" dataObjectRef="DataObject_08crhde" />
+    <bpmn:dataObject id="DataObject_08crhde" isCollection="true" />
+    <bpmn:dataObjectReference id="output" name="Output" dataObjectRef="DataObject_0airzvd" />
+    <bpmn:dataObject id="DataObject_0airzvd" isCollection="true" />
+    <bpmn:textAnnotation id="TextAnnotation_1ngbx0a">
+      <bpmn:text>Testing multiple instance output</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1rd0m1u" sourceRef="output" targetRef="TextAnnotation_1ngbx0a" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_04leo32_di" bpmnElement="Flow_04leo32">
+        <di:waypoint x="215" y="357" />
+        <di:waypoint x="270" y="357" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="339" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_131r2hz_di" bpmnElement="script">
+        <dc:Bounds x="270" y="317" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_0f414bj_di" bpmnElement="data_object">
+        <dc:Bounds x="302" y="525" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="308" y="582" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_0xf30zw_di" bpmnElement="output">
+        <dc:Bounds x="302" y="165" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="303" y="222" width="34" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1ngbx0a_di" bpmnElement="TextAnnotation_1ngbx0a">
+        <dc:Bounds x="340" y="80" width="170" height="40" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1rd0m1u_di" bpmnElement="Association_1rd0m1u">
+        <di:waypoint x="338" y="166" />
+        <di:waypoint x="372" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/activity/test_models/multi_loop_data_object_parallel.bpmn
+++ b/bpxe/src/activity/test_models/multi_loop_data_object_parallel.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0tg7ycw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_05bo8vg</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_05bo8vg" sourceRef="start" targetRef="Activity_0s9quw2" />
+    <bpmn:scriptTask id="Activity_0s9quw2">
+      <bpmn:incoming>Flow_05bo8vg</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics>
+          <bpmn:loopDataInputRef>data_object</bpmn:loopDataInputRef>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:script>notify();</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:dataObjectReference id="data_object" name="&#10;" dataObjectRef="DataObject_1lt20vp" />
+    <bpmn:dataObject id="DataObject_1lt20vp" isCollection="true" />
+    <bpmn:textAnnotation id="TextAnnotation_09cmk6f">
+      <bpmn:text>The collection in this data object will drive the instances</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1gon8rm" sourceRef="data_object" targetRef="TextAnnotation_09cmk6f" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_05bo8vg_di" bpmnElement="Flow_05bo8vg">
+        <di:waypoint x="215" y="357" />
+        <di:waypoint x="270" y="357" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="339" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y9uqu8_di" bpmnElement="Activity_0s9quw2">
+        <dc:Bounds x="270" y="317" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_0uo00xf_di" bpmnElement="data_object">
+        <dc:Bounds x="302" y="165" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="311" y="222" width="20" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_09cmk6f_di" bpmnElement="TextAnnotation_09cmk6f">
+        <dc:Bounds x="340" y="80" width="210" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1gon8rm_di" bpmnElement="Association_1gon8rm">
+        <di:waypoint x="338" y="166" />
+        <di:waypoint x="364" y="130" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/src/data_object.rs
+++ b/bpxe/src/data_object.rs
@@ -1,22 +1,125 @@
 //! # Data Objects
 use derive_more::*;
 use downcast_rs::{impl_downcast, DowncastSync};
+use dyn_clone::{clone_trait_object, DynClone};
 
-pub trait DataObject: DowncastSync + Send + Sync + 'static {}
+pub trait DataObject: DowncastSync + Send + Sync + DynClone + 'static {
+    /// Try sending in a data object into this data object
+    ///
+    /// If implementation is able to handle it, it should return `Ok(())`, otherwise
+    /// it should return `value` through `Err(value)`.
+    ///
+    /// This function is used primarily by [`DataObjectExt`] implementation for `Box<dyn
+    /// DataObject>`. If `try_send` returns `Err`, [`DataObjectExt::send`] will overwrite
+    /// the box's value with the given value.
+    ///
+    /// Default implementation returns `Err(value)`.
+    fn try_send(&mut self, value: Box<dyn DataObject>) -> Result<(), Box<dyn DataObject>> {
+        Err(value)
+    }
+}
+clone_trait_object!(DataObject);
 
 impl_downcast!(sync DataObject);
 
+pub trait DataObjectExt {
+    /// Sends a data object into another data object
+    ///
+    /// If the target data object has special handling for `send` (`Collection`, for example,
+    /// appends the value to its own list), then that's the behaviour that will be chosen.
+    ///
+    /// Otherwise, `send` will replace target data object with `value`
+    fn send(&mut self, value: Box<dyn DataObject>);
+}
+
+impl DataObjectExt for Box<dyn DataObject> {
+    fn send(&mut self, value: Box<dyn DataObject>) {
+        if let Err(value) = self.try_send(value) {
+            *self = value;
+        }
+    }
+}
+
 /// Empty data object
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Empty;
 impl DataObject for Empty {}
 
+/// Primitive data container
+///
+/// ## Note
+///
+/// This type is meant to store data types that aren't [`DataObject`] by themselves,
+/// so if, for example, you need to store a collection, use [`Collection`] instead of
+/// [`Container`]`<`[`std::vec::Vec`]`<T>>`
+#[derive(Clone, PartialEq)]
+pub struct Container<T: Send + Sync + Clone + 'static>(pub T);
+impl<T: Send + Sync + Clone + 'static> DataObject for Container<T> {}
+
 /// Collection data object
-#[derive(Deref, DerefMut)]
+#[derive(Deref, DerefMut, Clone)]
 #[deref(forward)]
 #[deref_mut(forward)]
 pub struct Collection(pub Vec<Box<dyn DataObject>>);
-impl DataObject for Collection {}
+impl DataObject for Collection {
+    fn try_send(&mut self, value: Box<dyn DataObject>) -> Result<(), Box<dyn DataObject>> {
+        self.0.push(value);
+        Ok(())
+    }
+}
+
+impl Collection {
+    /// Creates an empty [`Collection`]
+    pub fn new() -> Self {
+        Self(vec![])
+    }
+}
+
+impl Default for Collection {
+    fn default() -> Self {
+        Collection::new()
+    }
+}
 
 // Support for JSON data structures
 impl DataObject for serde_json::Value {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn send_to_empty_replaces() {
+        let mut data_object: Box<dyn DataObject> = Box::new(Empty);
+        data_object.send(Box::new(Container(1u8)));
+        assert!(matches!(
+            data_object.downcast::<Container<u8>>().map(|v| *v),
+            Ok(Container(1u8))
+        ));
+    }
+
+    #[test]
+    fn send_to_container_replaces() {
+        let mut data_object: Box<dyn DataObject> = Box::new(Container(true));
+        data_object.send(Box::new(Empty));
+        assert!(matches!(
+            data_object.downcast::<Empty>().map(|v| *v),
+            Ok(Empty)
+        ));
+    }
+
+    #[test]
+    fn send_to_collection_appends() {
+        let mut data_object: Box<dyn DataObject> = Box::new(Collection::new());
+        data_object.send(Box::new(Empty));
+        assert!(matches!(
+            data_object.downcast_ref::<Collection>(),
+            Some(Collection(v)) if v[0].downcast_ref::<Empty>().is_some()
+        ));
+        data_object.send(Box::new(Container(1u8)));
+        assert!(matches!(
+            data_object.downcast_ref::<Collection>(),
+            Some(Collection(v)) if matches!(v[1].downcast_ref::<Container<u8>>(), Some(Container(1)))
+        ));
+    }
+}

--- a/bpxe/src/data_object.rs
+++ b/bpxe/src/data_object.rs
@@ -1,0 +1,22 @@
+//! # Data Objects
+use derive_more::*;
+use downcast_rs::{impl_downcast, DowncastSync};
+
+pub trait DataObject: DowncastSync + Send + Sync + 'static {}
+
+impl_downcast!(sync DataObject);
+
+/// Empty data object
+#[derive(Debug, PartialEq)]
+pub struct Empty;
+impl DataObject for Empty {}
+
+/// Collection data object
+#[derive(Deref, DerefMut)]
+#[deref(forward)]
+#[deref_mut(forward)]
+pub struct Collection(pub Vec<Box<dyn DataObject>>);
+impl DataObject for Collection {}
+
+// Support for JSON data structures
+impl DataObject for serde_json::Value {}

--- a/bpxe/src/event/end_event.rs
+++ b/bpxe/src/event/end_event.rs
@@ -48,7 +48,7 @@ impl FlowNode for EndEvent {
         }
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::EndEvent(self.state.clone())
     }
 

--- a/bpxe/src/event/intermediate_catch_event.rs
+++ b/bpxe/src/event/intermediate_catch_event.rs
@@ -68,7 +68,7 @@ impl FlowNode for IntermediateCatchEvent {
         }
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::IntermediateCatchEvent(self.state.clone())
     }
 

--- a/bpxe/src/event/intermediate_throw_event.rs
+++ b/bpxe/src/event/intermediate_throw_event.rs
@@ -50,7 +50,7 @@ impl FlowNode for IntermediateThrowEvent {
         }
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::IntermediateThrowEvent(self.state.clone())
     }
 

--- a/bpxe/src/event/start_event.rs
+++ b/bpxe/src/event/start_event.rs
@@ -63,7 +63,7 @@ impl FlowNode for StartEvent {
         }
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::StartEvent(self.state.clone())
     }
 

--- a/bpxe/src/gateway/event_based.rs
+++ b/bpxe/src/gateway/event_based.rs
@@ -53,7 +53,7 @@ impl FlowNode for Gateway {
         self.process = Some(process);
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::EventBasedGateway(self.state.clone())
     }
 

--- a/bpxe/src/gateway/exclusive.rs
+++ b/bpxe/src/gateway/exclusive.rs
@@ -58,7 +58,7 @@ impl FlowNode for Gateway {
         self.process = Some(process);
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::ExclusiveGateway(self.state.clone())
     }
 

--- a/bpxe/src/gateway/inclusive.rs
+++ b/bpxe/src/gateway/inclusive.rs
@@ -71,7 +71,7 @@ impl FlowNode for Gateway {
         self.process = Some(process);
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::InclusiveGateway(self.state.clone())
     }
 

--- a/bpxe/src/gateway/parallel.rs
+++ b/bpxe/src/gateway/parallel.rs
@@ -50,7 +50,7 @@ impl FlowNode for Gateway {
         }
     }
 
-    fn get_state(&self) -> flow_node::State {
+    fn get_state(&mut self) -> flow_node::State {
         flow_node::State::ParallelGateway(self.state.clone())
     }
 

--- a/bpxe/src/language/mod.rs
+++ b/bpxe/src/language/mod.rs
@@ -1,7 +1,8 @@
-//! # Language expressions
+//! # Language expressions;
 //!
 //! These are used for condition expressions and scripts
 use crate::bpmn::schema::{FormalExpression, ScriptTask};
+use crate::data_object::DataObject;
 use async_trait::async_trait;
 use thiserror::Error;
 use tokio::task;
@@ -9,6 +10,7 @@ use tokio::task;
 #[cfg(feature = "rhai")]
 pub mod rhai;
 
+/// Information about the engine
 pub trait EngineInfo {
     /// Returns language's namespace
     fn namespace(&self) -> Option<&str> {
@@ -19,11 +21,37 @@ pub trait EngineInfo {
         None
     }
 }
+
+/// Engine context provider
+pub trait EngineContextProvider {
+    /// Context type
+    type Context: EngineContext;
+
+    /// Returns a newly initialized context
+    fn new_context(&self) -> Self::Context;
+}
+
+/// Engine execution context
+pub trait EngineContext {
+    /// Clears the context
+    fn clear(&mut self) -> &mut Self;
+
+    /// Sets a value in the context
+    fn set(&mut self, name: &str, value: Box<dyn DataObject>) -> &mut Self;
+}
+
 /// Language for expressions and/or scripts
 #[async_trait]
-pub trait Engine<Expr>: EngineInfo + Send + Sync {
+pub trait Engine<Expr>: EngineInfo + EngineContextProvider + Send + Sync
+where
+    Expr: Send + Sync + Unpin + 'static,
+{
     /// Evaluates a program using an engine for a given language
-    async fn eval<T>(&self, code: &Expr) -> Result<T, EvaluationError>
+    async fn eval<T>(
+        &self,
+        code: &Expr,
+        context: &mut <Self as EngineContextProvider>::Context,
+    ) -> Result<T, EvaluationError>
     where
         T: Send + Sync + Clone + 'static;
 }
@@ -108,7 +136,11 @@ impl EngineInfo for MultiLanguageEngine {}
 
 #[async_trait]
 impl Engine<FormalExpression> for MultiLanguageEngine {
-    async fn eval<T>(&self, code: &FormalExpression) -> Result<T, EvaluationError>
+    async fn eval<T>(
+        &self,
+        code: &FormalExpression,
+        context: &mut <Self as EngineContextProvider>::Context,
+    ) -> Result<T, EvaluationError>
     where
         T: Send + Sync + Clone + 'static,
     {
@@ -122,7 +154,7 @@ impl Engine<FormalExpression> for MultiLanguageEngine {
                 #[cfg(feature = "rhai")]
                 if let Some(ns) = self.rhai.namespace() {
                     if ns == language {
-                        return self.rhai.eval(code).await;
+                        return self.rhai.eval(code, &mut context.rhai_context).await;
                     }
                 }
                 return Err(EvaluationError::UnsupportedLanguage {
@@ -135,7 +167,11 @@ impl Engine<FormalExpression> for MultiLanguageEngine {
 
 #[async_trait]
 impl Engine<ScriptTask> for MultiLanguageEngine {
-    async fn eval<T>(&self, code: &ScriptTask) -> Result<T, EvaluationError>
+    async fn eval<T>(
+        &self,
+        code: &ScriptTask,
+        context: &mut <Self as EngineContextProvider>::Context,
+    ) -> Result<T, EvaluationError>
     where
         T: Send + Sync + Clone + 'static,
     {
@@ -149,13 +185,44 @@ impl Engine<ScriptTask> for MultiLanguageEngine {
                 #[cfg(feature = "rhai")]
                 if let Some(t) = self.rhai.mime_type() {
                     if t == language {
-                        return self.rhai.eval(code).await;
+                        return self.rhai.eval(code, &mut context.rhai_context).await;
                     }
                 }
                 return Err(EvaluationError::UnsupportedLanguage {
                     language: Some(language.into()),
                 });
             }
+        }
+    }
+}
+
+pub struct MultiLanguageEngineContext {
+    #[cfg(feature = "rhai")]
+    rhai_context: rhai::Context,
+}
+
+impl EngineContext for MultiLanguageEngineContext {
+    fn clear(&mut self) -> &mut Self {
+        #[cfg(feature = "rhai")]
+        self.rhai_context.clear();
+        self
+    }
+
+    /// Sets a value in the context
+    fn set(&mut self, name: &str, value: Box<dyn DataObject>) -> &mut Self {
+        #[cfg(feature = "rhai")]
+        self.rhai_context.set(name, dyn_clone::clone_box(&*value));
+        self
+    }
+}
+
+impl EngineContextProvider for MultiLanguageEngine {
+    type Context = MultiLanguageEngineContext;
+
+    fn new_context(&self) -> Self::Context {
+        MultiLanguageEngineContext {
+            #[cfg(feature = "rhai")]
+            rhai_context: self.rhai.new_context(),
         }
     }
 }
@@ -176,11 +243,14 @@ mod tests {
     async fn dispatch_to_rhai_evaluation() {
         let e = MultiLanguageEngine::new();
         assert!(e
-            .eval::<bool>(&FormalExpression {
-                language: Some(RHAI_URI.to_string()),
-                content: Some("true".into()),
-                ..Default::default()
-            })
+            .eval::<bool>(
+                &FormalExpression {
+                    language: Some(RHAI_URI.to_string()),
+                    content: Some("true".into()),
+                    ..Default::default()
+                },
+                &mut e.new_context()
+            )
             .await
             .unwrap());
     }

--- a/bpxe/src/lib.rs
+++ b/bpxe/src/lib.rs
@@ -14,6 +14,7 @@
 //! resumed with little to no consideration when a failure happen.
 pub mod activity;
 pub mod bpmn;
+pub mod data_object;
 pub mod event;
 pub mod flow_node;
 pub mod gateway;

--- a/bpxe/src/process/test_models/data_object.bpmn
+++ b/bpxe/src/process/test_models/data_object.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0xyzmm8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+  <bpmn:process id="proc1" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_0sjaqj0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:dataObjectReference id="data_object" dataObjectRef="DataObject" />
+    <bpmn:dataObject id="DataObject" />
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_0sjaqj0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0sjaqj0" sourceRef="start" targetRef="end" />
+    <bpmn:textAnnotation id="TextAnnotation_0ovfv6g">
+      <bpmn:text>We're testing access to data objects</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1sywrg9" sourceRef="data_object" targetRef="TextAnnotation_0ovfv6g" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="proc1">
+      <bpmndi:BPMNEdge id="Flow_0sjaqj0_di" bpmnElement="Flow_0sjaqj0">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_01dehym_di" bpmnElement="data_object">
+        <dc:Bounds x="224" y="185" width="36" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0z7zlv8_di" bpmnElement="end">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0ovfv6g_di" bpmnElement="TextAnnotation_0ovfv6g">
+        <dc:Bounds x="340" y="180" width="100" height="54" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1sywrg9_di" bpmnElement="Association_1sywrg9">
+        <di:waypoint x="260" y="208" />
+        <di:waypoint x="340" y="200" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpxe/tests/bpmn_test.rs
+++ b/bpxe/tests/bpmn_test.rs
@@ -19,7 +19,8 @@ fn parse_formal_expr() {
         .unwrap();
     assert!(
         matches!(&flow.condition_expression,
-            Some(Expr::FormalExpression(FormalExpression{ content: Some(content), .. })) if content == "a")
+            Some(SequenceFlowConditionExpression(Expr::FormalExpression(FormalExpression{ content: Some(content), .. })))
+            if content == "a")
     );
 }
 
@@ -34,7 +35,7 @@ fn parse_expr() {
         .unwrap();
     assert!(matches!(
         &flow.condition_expression,
-        Some(Expr::Expression(_))
+        Some(SequenceFlowConditionExpression(Expr::Expression(_)))
     ));
 }
 


### PR DESCRIPTION
This is often useful for processing data, sequentially and in parallel.

Solution: implement basic `multiInstanceLoopCharacteristics`

It's lacking support for data input / output as well as event behavour,
but that's coming soon. This is just a basic way to run multi-instance
loops.

This change introduces the concept of data objects which are currently
essentially just Box`es holding anything that can be downcasted. The
reasoning behind that is so that we don't want to stipulate any
particular formats too early.