### PR TITLE
Problem: failing deprecation notice lint

### DIFF
--- a/bpxe/Cargo.toml
+++ b/bpxe/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1"
 factory = "0.1.2"
 num-bigint = { version = "0.3.1", features = ["serde"] }
 serde_json = "1.0"
-streamunordered = "0.5.1"
+streamunordered = "^0.5.2"
 derive_more = "0.99.11"
 instant = "0.1.9"
 

--- a/bpxe/src/activity/mod.rs
+++ b/bpxe/src/activity/mod.rs
@@ -149,7 +149,7 @@ where
         let mut flow_node_tokens = vec![];
         let mut flow_nodes = StreamUnordered::new();
         for activity in activities.drain(..) {
-            flow_node_tokens.push(flow_nodes.push(activity));
+            flow_node_tokens.push(flow_nodes.insert(activity));
         }
 
         let properties = element
@@ -986,7 +986,7 @@ where
                             activity.set_process(process);
                         }
 
-                        let token = me.flow_nodes.push(activity);
+                        let token = me.flow_nodes.insert(activity);
                         me.flow_node_tokens.push(token);
 
                         // 2. Save input data

--- a/bpxe/src/process/scheduler.rs
+++ b/bpxe/src/process/scheduler.rs
@@ -97,7 +97,7 @@ impl Scheduler {
             })
         {
             let element = flow_node.element();
-            let token = flow_nodes.push(flow_node);
+            let token = flow_nodes.insert(flow_node);
             for (index, outgoing) in element.outgoings().iter().enumerate() {
                 flow_nodes_outgoing.insert(outgoing.to_owned(), (token, index));
             }


### PR DESCRIPTION
cargo clippy fails with:

```
error: use of deprecated associated function `streamunordered::StreamUnordered::<S>::push`: Prefer StreamUnordered::insert
   --> bpxe/src/activity/mod.rs:152:46
    |
152 |             flow_node_tokens.push(flow_nodes.push(activity));
    |                                              ^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
```

Solution: use the new API

The change was introduced here https://github.com/jonhoo/streamunordered/commit/cd203a48c3cd566b34840d16a6ab439ac618da73