### PR TITLE
Problem: having to pass worker's global scope (self)

### DIFF
--- a/bpxe/src/wasm.rs
+++ b/bpxe/src/wasm.rs
@@ -9,6 +9,12 @@ use tokio::sync::oneshot;
 use wasm_bindgen::prelude::*;
 use wasm_rs_shared_channel::spsc;
 
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = "self")]
+    static scope: web_sys::DedicatedWorkerGlobalScope;
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Request {
     id: u32,
@@ -53,7 +59,7 @@ impl Channel {
         self.receiver.as_ref().unwrap().0.clone().into()
     }
 
-    pub fn run(&mut self, scope: web_sys::DedicatedWorkerGlobalScope) -> Result<(), JsValue> {
+    pub fn run(&mut self) -> Result<(), JsValue> {
         console_error_panic_hook::set_once();
         let receiver = self.receiver.take().unwrap();
         let (sender, mut rcvr) = oneshot::channel();

--- a/examples/bpxe_wasm_demo/worker.js
+++ b/examples/bpxe_wasm_demo/worker.js
@@ -7,7 +7,7 @@ wasm_bindgen("node_modules/bpxe/web/bpxe_bg.wasm").then(() => {
 onmessage = (msg) => {
 	let channel = self.module.Channel.from(msg.data);
 	while (true) {
-	  channel.run(self);
+	  channel.run();
 	  console.debug("worker: runner terminated, restarting");
 	}
 }


### PR DESCRIPTION
Currently, in order to start BPXE in a worker thread, `self` of the
worker (its global scope) needs to be passed into `Channel.run`

Solution: declare scope (`self`) as a static so that it can be accessed
directly