### PR TITLE
Problem: using correct rust toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,4 @@
+[toolchain]
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]
+channel = "stable"

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,17 @@
-{ 
-  pkgs ? import (fetchTarball https://nixos.org/channels/nixos-unstable/nixexprs.tar.xz) {}
-}:
-
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+  rustChannel = (pkgs.rustChannelOf { channel = "stable";  });
+  rust = (rustChannel.rust.override {
+    targets = ["wasm32-unknown-unknown"];
+  });
+in
 pkgs.stdenv.mkDerivation rec {
   name = "bpxe-shell";
 
-  buildInputs = with pkgs; [ saxon-he rustc cargo clippy rustfmt 
+  buildInputs = with pkgs; [ saxon-he
+                             rust
+                             chromedriver # for wasm-pack test --chrome
                              openssl.dev pkgconfig # for cargo-release
   ];
 


### PR DESCRIPTION
I mainly develop on NixOS and shell.nix as it is is no longer
satisfactory. I can't develop wasm stuff as there's no
wasm32-unknown-unknown target.

Solution: use Mozilla overlays for Rust
and set it to stable + wasm32-unknown-unknown

Also, while we're at it, add a `rust-toolchain` file to specify the same
settings for `rustup` setups (I also have a computer that uses `rustup`
approach)