### PR TITLE
Problem: wasm example setup is somewhat convoluted

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,16 +1,11 @@
-[tasks.bpxe-js-wasm-web]
-command = "wasm-pack"
-args = ["build", "--release", "--target", "no-modules", "-d", "pkg/web", "bpxe"]
-
 [tasks.bpxe-js-wasm]
 command = "wasm-pack"
 args = ["build", "--release", "bpxe"]
 
 [tasks.bpxe-js]
-dependencies = ["bpxe-js-wasm", "bpxe-js-wasm-web"]
+dependencies = ["bpxe-js-wasm"]
 script = [
    "cp bpxe/pkg/bpxe_bg* bpxe/pkg/bpxe.js bpxe/pkg/bpxe.d.ts bpxe.js",
-   "cp -R bpxe/pkg/web bpxe.js"
 ]
 
 [tasks.js]

--- a/examples/bpxe_wasm_demo/bootstrap.js
+++ b/examples/bpxe_wasm_demo/bootstrap.js
@@ -1,5 +1,3 @@
-// A dependency graph that contains any wasm must all be imported
-// asynchronously. This `bootstrap.js` file does the single async import, so
-// that no one else needs to worry about it again.
-import("./index.js")
-  .catch(e => console.error("Error importing `index.js`:", e));
+import("bpxe/bpxe_bg.wasm")
+.then(wasm => import("./index.js"))
+.catch(e => console.error("Error importing `index.js`:", e));

--- a/examples/bpxe_wasm_demo/index.js
+++ b/examples/bpxe_wasm_demo/index.js
@@ -1,8 +1,9 @@
 import * as bpxe from "bpxe";
 import demo from "./demo.bpmn";
+import Worker from "./worker.js";
 window.demo = demo;
 
-let worker = new Worker("worker.js");
+let worker = Worker();
 
 worker.onmessage = (e) => {
 	if (e.data == "started") {

--- a/examples/bpxe_wasm_demo/package.json
+++ b/examples/bpxe_wasm_demo/package.json
@@ -1,38 +1,19 @@
 {
-  "name": "create-wasm-app",
-  "version": "0.1.0",
-  "description": "create an app to consume rust-generated wasm packages",
+  "name": "bpxe-demo",
   "main": "index.js",
-  "bin": {
-    "create-wasm-app": ".bin/create-wasm-app.js"
-  },
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "start": "webpack-dashboard -- webpack-dev-server"
+    "start": "webpack serve"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/rustwasm/create-wasm-app.git"
-  },
-  "keywords": [
-    "webassembly",
-    "wasm",
-    "rust",
-    "webpack"
-  ],
-  "bugs": {
-    "url": "https://github.com/rustwasm/create-wasm-app/issues"
-  },
-  "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
   "dependencies": {
     "bpxe": "file:../../bpxe.js"
   },
   "devDependencies": {
-    "copy-webpack-plugin": "^5.0.0",
+    "copy-webpack-plugin": "^7",
     "raw-loader": "^4.0.2",
-    "webpack": "^4.29.3",
-    "webpack-cli": "^3.1.0",
-    "webpack-dashboard": "^3.3.1",
-    "webpack-dev-server": "^3.1.5"
+    "webpack": "^5",
+    "webpack-cli": "^4",
+    "webpack-dev-server": "^3.11.2",
+    "worker-loader": "^3.0.7"
   }
 }

--- a/examples/bpxe_wasm_demo/webpack.config.js
+++ b/examples/bpxe_wasm_demo/webpack.config.js
@@ -9,10 +9,16 @@ module.exports = {
   },
   mode: "development",
   plugins: [
-    new CopyWebpackPlugin(['index.html'])
+    new CopyWebpackPlugin({
+	    patterns: [{from: './index.html'}]
+    })
   ],
   module: {
 	  rules: [
+		  {
+			  test: /worker\.js$/,
+			  use: { loader: "worker-loader" },
+		  },
 		  {
 			  test: /\.bpmn$/i,
 			  use: [
@@ -21,6 +27,13 @@ module.exports = {
 				  },
 			  ],
 		  }
+
 	  ],
   },
+  devServer: {
+    hot: true
+  },
+  experiments: {
+    asyncWebAssembly: true
+  }
 };

--- a/examples/bpxe_wasm_demo/worker.js
+++ b/examples/bpxe_wasm_demo/worker.js
@@ -1,13 +1,14 @@
-importScripts("node_modules/bpxe/web/bpxe.js");
-wasm_bindgen("node_modules/bpxe/web/bpxe_bg.wasm").then(() => {
-	self.module = wasm_bindgen;
-	postMessage("started")
+worker = self;
+import("bpxe/bpxe_bg.wasm")
+.then(wasm => {
+	import("bpxe/bpxe.js").then(module => {
+		postMessage("started");
+		worker.onmessage = (msg) => {
+			let channel = module.Channel.from(msg.data);
+			while (true) {
+				channel.run();
+				console.debug("worker: runner terminated, restarting");
+			}
+		}
+	})
 });
-
-onmessage = (msg) => {
-	let channel = self.module.Channel.from(msg.data);
-	while (true) {
-	  channel.run();
-	  console.debug("worker: runner terminated, restarting");
-	}
-}


### PR DESCRIPTION
It requires bulding two versions of the wasm crate for bpxe.js,
use of globals, etc.

Solution: switch to a simpler async wasm module initialization
using Webpack 5