### PR TITLE
Problem: running singular activities more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial support for wasm32 (to enable running BPXE in the browser)
 
+### Fixed
+
+- Singular activities were executed more than once
+
 ## [0.2.0] - 2021-01-31
 
 ### Added

--- a/bpxe/Cargo.toml
+++ b/bpxe/Cargo.toml
@@ -39,6 +39,7 @@ derive_more = "0.99.11"
 instant = "0.1.9"
 wasm-rs-dbg = "0.1.0"
 wasm-rs-async-executor = { version = "^0.4.1", features = ["debug"] }
+num-traits = "0.2.14"
 
 [dev-dependencies]
 serde_yaml = "0.8"


### PR DESCRIPTION
I've noticed that simple workflows containing a singular activity (no
looping) execute more than once.

Solution: use counter to prevent subsequent re-execution of such activities
at the `ActivityContainer` container level, as this is the code
responsible for the bug