### PR TITLE
Problem: using outdated wasm-rs-async-executor

### DIFF
--- a/bpxe-internal-macros/src/lib.rs
+++ b/bpxe-internal-macros/src/lib.rs
@@ -35,7 +35,7 @@ pub fn test(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
         let wrapper: TokenStream = quote! {
             {
-               let result = wasm_rs_async_executor::single_threaded::run(Some(wasm_rs_async_executor::single_threaded::spawn(async { #(#stmts)* })));
+               let result = wasm_rs_async_executor::single_threaded::run(Some(wasm_rs_async_executor::single_threaded::spawn(async { #(#stmts)* }).task()));
                wasm_rs_async_executor::single_threaded::evict_all();
                result
             }

--- a/bpxe/Cargo.toml
+++ b/bpxe/Cargo.toml
@@ -38,7 +38,7 @@ streamunordered = "^0.5.2"
 derive_more = "0.99.11"
 instant = "0.1.9"
 wasm-rs-dbg = "0.1.0"
-wasm-rs-async-executor = { version = "^0.4.1", features = ["debug"] }
+wasm-rs-async-executor = { version = "^0.8.0", features = ["debug"] }
 num-traits = "0.2.14"
 
 [dev-dependencies]

--- a/bpxe/src/sys/task.rs
+++ b/bpxe/src/sys/task.rs
@@ -7,66 +7,26 @@ pub(crate) use tokio::task::*;
 #[cfg(any(target_arch = "wasm32", feature = "wasm-executor"))]
 mod wasm {
     use std::future::Future;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    use thiserror::Error;
-    use tokio::sync::oneshot;
+    use wasm_rs_async_executor::single_threaded as executor;
 
-    pub(crate) struct JoinHandle<T>(oneshot::Receiver<T>)
-    where
-        T: Send + 'static;
+    pub type JoinHandle<T> = executor::TaskHandle<T>;
+    pub type JoinError = executor::JoinError;
 
-    impl<T> Future for JoinHandle<T>
-    where
-        T: Send + 'static,
-    {
-        type Output = Result<T, JoinError>;
-
-        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-            match self.0.try_recv() {
-                Ok(val) => Poll::Ready(Ok(val)),
-                Err(oneshot::error::TryRecvError::Empty) => Poll::Pending,
-                Err(_) => Poll::Ready(Err(JoinError)),
-            }
-        }
-    }
-
-    // TODO: make this error match tokio::task::JoinError (at least somewhat)
-    #[derive(Error, Debug)]
-    #[error("join error")]
-    pub(crate) struct JoinError;
-
-    #[allow(dead_code)]
-    impl JoinError {
-        pub(crate) fn is_cancelled(&self) -> bool {
-            false
-        }
-        pub(crate) fn is_panic(&self) -> bool {
-            true
-        }
-    }
-
-    pub(crate) fn spawn<T>(task: T) -> JoinHandle<T::Output>
+    pub(crate) fn spawn<T>(task: T) -> executor::TaskHandle<T::Output>
     where
         T: Future + 'static,
         T::Output: Send + 'static,
     {
-        let (sender, receiver) = oneshot::channel();
-        let _ = wasm_rs_async_executor::single_threaded::spawn(async move {
-            let _ = sender.send(task.await);
-        });
-        JoinHandle(receiver)
+        executor::spawn(task)
     }
 
-    pub(crate) fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
+    pub(crate) fn spawn_blocking<F, R>(f: F) -> executor::TaskHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
         // TODO: we need to do this in a worker
-        let (sender, receiver) = oneshot::channel();
-        let _ = sender.send(f());
-        JoinHandle(receiver)
+        executor::spawn(async { f() })
     }
 
     pub use tokio::task::yield_now;


### PR DESCRIPTION
A lot has changed since 0.4.1, might be missing out on some critical
changes. The API has changed a bit as well.

Solution: upgrade it to 0.8.0