### PR TITLE
Problem: no CI tests for WebAssembly

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasi]
+runner = "wasmtime"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,3 +70,49 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  wasm:
+    name: WebAssembly
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        toolchain: ['stable']
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Install ${{matrix.toolchain}} toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: wasm32-wasi
+          toolchain: ${{matrix.toolchain}}
+          override: true
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.3.0
+        with:
+          version: 'latest'
+
+      - name: Use wasmtime 0.23.0
+        uses: mwilliamson/setup-wasmtime-action@v1
+        with:
+          wasmtime-version: "0.23.0"
+      
+      - name: Check if it tests under wasmtime
+        run: |-
+          cargo test --target wasm32-wasi --all-features
+
+      - name: Check if it tests under Chrome
+        run: |-
+         echo SKIP wasm-pack test --chrome --headless bpxe -- --all-features
+         echo SKIP wasm-pack test --chrome --headless bpxe-bpmn-schema -- --all-features

--- a/bpxe-bpmn-schema/Cargo.toml
+++ b/bpxe-bpmn-schema/Cargo.toml
@@ -26,10 +26,10 @@ syn = "1.0.60"
 serde = { version = "1.0.119", features = ["derive"] }
 derive_more = "0.99.11"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "0.2"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3", features = ["console"] }
 console_error_panic_hook = "0.1.6"

--- a/bpxe-bpmn-schema/src/lib.rs
+++ b/bpxe-bpmn-schema/src/lib.rs
@@ -173,7 +173,7 @@ impl Process {
     }
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[cfg(test)]

--- a/bpxe/Cargo.toml
+++ b/bpxe/Cargo.toml
@@ -37,8 +37,8 @@ serde_json = "1.0"
 streamunordered = "^0.5.2"
 derive_more = "0.99.11"
 instant = "0.1.9"
-wasm-rs-dbg = "0.1.0"
-wasm-rs-async-executor = { version = "^0.8.0", features = ["debug"] }
+wasm-rs-dbg = "^0.1.2"
+wasm-rs-async-executor = { version = "^0.8.1", features = ["debug"] }
 num-traits = "0.2.14"
 
 [dev-dependencies]
@@ -48,7 +48,7 @@ ron = "0.6"
 rmp-serde = "0.15"
 pin-project = "1"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 console_error_panic_hook = "0.1.6"
 wasm-rs-shared-channel = "0.1.0"
 wasm-bindgen-futures = "0.4.20"
@@ -56,12 +56,12 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["console", "DedicatedWorkerGlobalScope"] }
 tokio = { version = "1.1", features = ["macros", "time", "sync"] }
-data-url-encode-macro = "1.0.1"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.wasm32-wasi.dependencies]
+tokio = { version = "1.1", features = ["macros", "time", "sync"] }
+
+[target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"
-console_error_panic_hook = "0.1.6"
 
 [features]
 default = ["rhai"]
-wasm-executor = []

--- a/bpxe/src/activity/mod.rs
+++ b/bpxe/src/activity/mod.rs
@@ -1157,7 +1157,6 @@ mod tests {
         model.terminate().await;
     }
 
-    #[cfg(not(any(feature = "wasm-executor", target_arch = "wasm32")))]
     #[cfg(feature = "rhai")]
     #[bpxe_im::test]
     async fn standard_loop_after() {
@@ -1209,7 +1208,7 @@ mod tests {
         model.terminate().await;
     }
 
-    #[cfg(not(any(feature = "wasm-executor", target_arch = "wasm32")))]
+    #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "rhai")]
     #[bpxe_im::test]
     async fn standard_loop_test_before() {
@@ -1267,7 +1266,7 @@ mod tests {
         model.terminate().await;
     }
 
-    #[cfg(not(any(feature = "wasm-executor", target_arch = "wasm32")))]
+    #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "rhai")]
     #[bpxe_im::test]
     async fn standard_loop_max() {
@@ -1358,7 +1357,7 @@ mod tests {
     }
 
     // TODO: Barrier isn't available for wasm32
-    #[cfg(not(any(feature = "wasm-executor", target_arch = "wasm32")))]
+    #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "rhai")]
     #[bpxe_im::test]
     async fn multi_loop_cardinality_parallel() {
@@ -1450,7 +1449,7 @@ mod tests {
     }
 
     // TODO: Barrier isn't available for wasm32
-    #[cfg(not(any(feature = "wasm-executor", target_arch = "wasm32")))]
+    #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "rhai")]
     #[bpxe_im::test]
     async fn multi_loop_data_object_parallel() {

--- a/bpxe/src/lib.rs
+++ b/bpxe/src/lib.rs
@@ -21,13 +21,13 @@ pub mod gateway;
 pub mod language;
 pub mod model;
 pub mod process;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod wasm;
 
 pub(crate) mod serde;
 pub(crate) mod sys;
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[cfg(test)]

--- a/bpxe/src/sys/task.rs
+++ b/bpxe/src/sys/task.rs
@@ -1,10 +1,10 @@
 //! # Task helpers
 //!
 
-#[cfg(not(any(target_arch = "wasm32", feature = "wasm-executor")))]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) use tokio::task::*;
 
-#[cfg(any(target_arch = "wasm32", feature = "wasm-executor"))]
+#[cfg(target_arch = "wasm32")]
 mod wasm {
     use std::future::Future;
     use wasm_rs_async_executor::single_threaded as executor;
@@ -42,5 +42,5 @@ mod wasm {
     }
 }
 
-#[cfg(any(target_arch = "wasm32", feature = "wasm-executor"))]
+#[cfg(target_arch = "wasm32")]
 pub(crate) use wasm::*;

--- a/bpxe/tests/bpmn_test.rs
+++ b/bpxe/tests/bpmn_test.rs
@@ -2,7 +2,7 @@ use bpxe;
 use bpxe::bpmn::schema::*;
 use bpxe_internal_macros as bpxe_im;
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[bpxe_im::test]
@@ -66,7 +66,7 @@ fn serialize_deserialize_serde_json() {
     assert_eq!(definitions_1, definitions);
 }
 
-#[cfg(not(target_arch = "wasm32"))] // ignore on wasm32 for now
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))] // ignore on wasm32-unknown for now
 #[bpxe_im::test]
 #[ignore] // FIXME: https://github.com/bpxe/bpxe.rs/issues/3
 fn serialize_deserialize_serde_toml() {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "wasm32-wasi"]
 components = ["rustfmt", "clippy"]
 channel = "stable"

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
   pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
   rustChannel = (pkgs.rustChannelOf { channel = "stable";  });
   rust = (rustChannel.rust.override {
-    targets = ["wasm32-unknown-unknown"];
+    targets = ["wasm32-unknown-unknown" "wasm32-wasi"];
   });
 in
 pkgs.stdenv.mkDerivation rec {


### PR DESCRIPTION
Solution: ensure BPXE can run under WASI and Browser

This change also removes `wasm-executor` feature which was intended to
be used for testing BPXE code with wasm-executor, but isn't it better to
actually test it in an actual WebAssembly environment?

GitHub Actions, however, seems to hang on tests when they executed in a
browser (this has been the case before) so the CI steps for that are
disabled for now. At least we're testing WASI-flavoured build now.