### PR TITLE
Problem: `DocumentElement` is not `DynClone`

### DIFF
--- a/bpxe-bpmn-schema/codegen-rust.xsl
+++ b/bpxe-bpmn-schema/codegen-rust.xsl
@@ -196,7 +196,7 @@
         <xsl:text>}</xsl:text>
         
         <xsl:text>
-            pub trait DocumentElement:
+            pub trait DocumentElement: DynClone +
         </xsl:text>
         <xsl:for-each select="$schema/xs:complexType">
             <xsl:text xml:space="preserve">Cast&lt;dyn </xsl:text><xsl:value-of select="local:struct-case(./@name)"/><xsl:text>Type&gt;</xsl:text>

--- a/bpxe-bpmn-schema/src/lib.rs
+++ b/bpxe-bpmn-schema/src/lib.rs
@@ -410,3 +410,17 @@ fn find_by_id_mut() {
 
     assert!(definitions.find_by_id_mut("not_to_be_found").is_none());
 }
+
+#[cfg(test)]
+#[bpxe_im::test]
+fn document_element_clone() {
+    let mut proc: Process = Default::default();
+    proc.id = Some("proc".into());
+    let mut definitions: Definitions = Default::default();
+    definitions.root_elements.push(RootElement::Process(proc));
+    if let Some(proc_) = definitions.find_by_id("proc") {
+        dyn_clone::clone_box(proc_);
+    } else {
+        unreachable!();
+    }
+}


### PR DESCRIPTION
However, its implementers, as it happens, are. This means that might not
be able to do a dynamic clone of a given DocumentElement.

Solution: make sure it implements `DynClone` as well