### PR TITLE
Problem: shell.nix exports PATH

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,9 +10,4 @@ pkgs.stdenv.mkDerivation rec {
                              openssl.dev pkgconfig # for cargo-release
   ];
 
-  shellHook = ''
-    # Useful for ensuring cargo tools are available (like cargo-do, for example)
-    export PATH=$PATH:$HOME/.cargo/bin
-  '';
-
 }


### PR DESCRIPTION
However, it doesn't seem to be neccessary anymore since we've switched
to rustup.

Solution: remove the export